### PR TITLE
fix: Make metrics upload workflow resilient to check failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,8 @@ jobs:
       - lint
     runs-on: ubuntu-latest
     if: ${{ always() }}
+    env:
+      RUN_ID: ${{ github.run_id }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -88,17 +90,24 @@ jobs:
             sh -s -- -b "$(go env GOPATH)"/bin v1.55.2
           go install github.com/securego/gosec/v2/cmd/gosec@v2.19.0
       - name: Run make check with metrics
+        continue-on-error: true
+        id: check
         run: make check METRICS=true
       - name: Upload metrics artifact (dry run)
         env:
           METRICS_BUCKET: ai-aas-build-metrics
         run: |
-          FILE=$(ls -t scripts/metrics/output/*.json | head -n 1)
-          echo "Uploading $FILE"
-          ./scripts/metrics/upload.sh --dry-run "$FILE"
+          if [ -d "scripts/metrics/output" ] && [ -n "$(ls -A scripts/metrics/output/*.json 2>/dev/null)" ]; then
+            FILE=$(ls -t scripts/metrics/output/*.json | head -n 1)
+            echo "Uploading $FILE"
+            ./scripts/metrics/upload.sh --dry-run "$FILE"
+          else
+            echo "No metrics files found, skipping upload"
+          fi
       - name: Archive metrics artifact
         uses: actions/upload-artifact@v4
         with:
           name: metrics-json
           path: scripts/metrics/output/*.json
+          if-no-files-found: warn
 


### PR DESCRIPTION
## Summary

Fixes the Metrics Upload workflow to handle failures gracefully and ensure metrics are collected even when `make check` fails.

## Problem

The Metrics Upload step was failing because:
1. When `make check` failed, the workflow step exited before metrics collection could complete
2. The upload step failed when no JSON files existed (`ls` command failed)
3. The archive step failed when the path didn't exist or had no files

## Solution

- **Added RUN_ID environment variable** using `github.run_id` for consistent tracking
- **Made check step resilient** with `continue-on-error: true` to allow metrics collection even when checks fail
- **Handle missing files gracefully** in upload step with conditional checks
- **Make artifact archiving optional** with `if-no-files-found: warn` to prevent failures

## Changes

- `.github/workflows/ci.yml`: Updated metrics-upload job to be resilient to check failures

## Testing

- Workflow should complete successfully even when `make check` fails
- Metrics should be collected and archived when available
- No false failures when metrics files don't exist

## Related

- Addresses metrics upload failures in CI pipeline