### PR TITLE
feat: Add OTLP collector and configure vLLM model name for API compatibility

### DIFF
--- a/infra/k8s/monitoring/otel-collector.yaml
+++ b/infra/k8s/monitoring/otel-collector.yaml
@@ -1,0 +1,99 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: monitoring
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: otel-collector-config
+  namespace: monitoring
+data:
+  otel-collector-config.yaml: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:4317
+          http:
+            endpoint: 0.0.0.0:4318
+
+    processors:
+      batch:
+        timeout: 10s
+        send_batch_size: 1024
+
+    exporters:
+      # Logging exporter for debugging
+      logging:
+        verbosity: basic
+      # No-op exporter - just accepts and drops traces
+      # Can be replaced with real backends later (Jaeger, Prometheus, etc.)
+
+    service:
+      pipelines:
+        traces:
+          receivers: [otlp]
+          processors: [batch]
+          exporters: [logging]
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: otel-collector
+  namespace: monitoring
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: otel-collector
+  template:
+    metadata:
+      labels:
+        app: otel-collector
+    spec:
+      containers:
+      - name: otel-collector
+        image: otel/opentelemetry-collector:0.91.0
+        args:
+        - --config=/conf/otel-collector-config.yaml
+        ports:
+        - containerPort: 4317
+          name: otlp-grpc
+          protocol: TCP
+        - containerPort: 4318
+          name: otlp-http
+          protocol: TCP
+        volumeMounts:
+        - name: config
+          mountPath: /conf
+        resources:
+          limits:
+            cpu: 200m
+            memory: 256Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+      volumes:
+      - name: config
+        configMap:
+          name: otel-collector-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: otel-collector
+  namespace: monitoring
+spec:
+  type: ClusterIP
+  ports:
+  - port: 4317
+    targetPort: 4317
+    protocol: TCP
+    name: otlp-grpc
+  - port: 4318
+    targetPort: 4318
+    protocol: TCP
+    name: otlp-http
+  selector:
+    app: otel-collector

--- a/infra/k8s/vllm-manual-gpu.yaml
+++ b/infra/k8s/vllm-manual-gpu.yaml
@@ -58,6 +58,7 @@ spec:
           - vllm.entrypoints.openai.api_server
         args:
           - --model=unsloth/gpt-oss-20b
+          - --served-model-name=gpt-oss-20b
           - --device=cuda
           - --kv-cache-dtype=fp8
           - --gpu-memory-utilization=0.9


### PR DESCRIPTION
This PR adds infrastructure for OpenTelemetry collection and configures vLLM to serve the model with an industry-standard name.

## Changes
- Add OTLP collector deployment for monitoring namespace
- Configure vLLM to serve model as 'gpt-oss-20b' instead of 'unsloth/gpt-oss-20b'
- Follows industry naming conventions (OpenAI: gpt-4, Anthropic: claude-3-sonnet)

## Testing
- ✅ End-to-end inference with model='gpt-oss-20b'
- ✅ Authentication → Routing → vLLM → Response
- ✅ OTLP collector accepting telemetry

Builds on commits already on main:
- 36182989: Configure API Router for end-to-end inference
- 31f61afd: Configure ArgoCD to use OTLP collector
- 58cb94d9: Fix authentication context key type mismatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)