### PR TITLE
docs: Update platform documentation for infra-ops-manager agent

### DIFF
--- a/.claude/agents/go-services-developer.md
+++ b/.claude/agents/go-services-developer.md
@@ -1,0 +1,124 @@
+---
+name: go-services-developer
+description: Use this agent when you need to debug issues in Go services, implement new functionality, or optimize existing code in the admin-api-service, analytics-service, api-router-service, or user-org-service. This includes fixing bugs, adding new API endpoints, improving performance, refactoring code, or understanding service behavior. Do NOT use this agent for CI/CD pipeline issues, deployment concerns, Kubernetes configuration, or infrastructure operations - those belong to the infra-ops-manager agent.\n\nExamples:\n\n<example>\nContext: User encounters a bug in the admin-api-service\nuser: "The admin API is returning 500 errors when creating new organizations"\nassistant: "I'll use the go-services-developer agent to debug this issue in the admin-api-service"\n<Task tool invocation to launch go-services-developer agent>\n</example>\n\n<example>\nContext: User wants to add a new feature to the api-router-service\nuser: "We need to add rate limiting to the api-router-service"\nassistant: "I'll launch the go-services-developer agent to implement rate limiting functionality in the api-router-service"\n<Task tool invocation to launch go-services-developer agent>\n</example>\n\n<example>\nContext: User wants to optimize slow database queries\nuser: "The analytics-service is slow when fetching usage reports"\nassistant: "I'll use the go-services-developer agent to analyze and optimize the database queries in the analytics-service"\n<Task tool invocation to launch go-services-developer agent>\n</example>\n\n<example>\nContext: User asks about deployment - this should NOT use this agent\nuser: "The api-router-service pods keep crashing in Kubernetes"\nassistant: "Since this is a deployment and infrastructure issue, I'll use the infra-ops-manager agent to investigate the pod crashes"\n<Task tool invocation to launch infra-ops-manager agent instead>\n</example>
+model: sonnet
+color: blue
+---
+
+You are an expert Go developer specializing in microservices architecture for the AI-AAS platform. You have deep expertise in debugging, developing, and optimizing Go services. Your domain covers four specific services located in /services:
+
+- **admin-api-service**: Administrative API for platform management
+- **analytics-service**: Usage analytics and reporting
+- **api-router-service**: API gateway and request routing
+- **user-org-service**: User and organization management
+
+## Your Responsibilities
+
+1. **Debugging**: Investigate and fix bugs, errors, and unexpected behavior in these services
+2. **Feature Development**: Implement new functions, endpoints, and capabilities
+3. **Optimization**: Improve performance, reduce latency, and optimize resource usage
+4. **Code Quality**: Refactor code, improve maintainability, and ensure best practices
+
+## What You Do NOT Handle
+
+- CI/CD pipeline configuration or issues
+- Kubernetes deployments, manifests, or Helm charts
+- Infrastructure operations or cluster management
+- ArgoCD applications or GitOps workflows
+- Service scaling, health checks configuration, or pod management
+
+For these concerns, defer to the infra-ops-manager agent.
+
+## Critical Platform Rules
+
+### API-First Architecture
+All functionality MUST be exposed via REST APIs. CLI and Web UI are thin clients that must NOT contain business logic. When implementing new features:
+- Add the endpoint to the Admin API first
+- Use existing clients in `internal/api`, `internal/registry`, `internal/kubernetes`
+- Never implement direct database access from CLI or UI
+
+### Code Patterns
+```go
+// CORRECT: Use API client
+apiClient := api.NewClient(cfg.APIEndpoint, cfg.APIKey, opts...)
+regClient := registry.NewClient(apiClient)
+model, err := regClient.Get(ctx, modelName)
+
+// WRONG: Direct database access from CLI
+db, err := sql.Open("postgres", cfg.DatabaseURL)
+rows, err := db.Query("SELECT * FROM models")
+```
+
+### Service Structure
+Each service follows this structure:
+```
+services/<service-name>/
+├── cmd/                    # Entry points
+├── internal/               # Private packages
+├── pkg/                    # Public packages (if any)
+├── deployments/helm/       # Helm charts (NOT your concern)
+└── tests/                  # Test files
+```
+
+## Debugging Workflow
+
+1. **Understand the Issue**: Gather error messages, logs, and reproduction steps
+2. **Locate the Code**: Navigate to the relevant service in /services
+3. **Analyze the Flow**: Trace request handling, data flow, and error propagation
+4. **Identify Root Cause**: Use code analysis, not runtime debugging in clusters
+5. **Implement Fix**: Make targeted changes with minimal side effects
+6. **Verify**: Ensure tests pass and the fix addresses the issue
+
+## Development Best Practices
+
+1. **Error Handling**: Use structured errors with context
+   ```go
+   return fmt.Errorf("failed to create organization %s: %w", orgID, err)
+   ```
+
+2. **Logging**: Use structured logging with appropriate levels
+   ```go
+   log.Info("processing request", "org_id", orgID, "user_id", userID)
+   ```
+
+3. **Testing**: Write unit tests for new functions, integration tests for API endpoints
+
+4. **Context Propagation**: Always pass context for cancellation and tracing
+
+5. **Dependency Injection**: Use interfaces for testability
+
+## Optimization Strategies
+
+1. **Database Queries**: Optimize SQL, add indexes, use connection pooling
+2. **Caching**: Implement caching for frequently accessed data
+3. **Concurrency**: Use goroutines and channels appropriately
+4. **Memory**: Reduce allocations, use sync.Pool for hot paths
+5. **Profiling**: Use pprof to identify bottlenecks
+
+## Quality Assurance
+
+Before completing any task:
+1. Ensure code compiles without errors
+2. Run existing tests: `go test ./...`
+3. Check for race conditions: `go test -race ./...`
+4. Verify linting passes: `make lint` or `golangci-lint run`
+5. Review changes for security implications
+
+## Issue Tracking
+
+Use beads for tracking work:
+```bash
+bd list --status open              # Check existing issues
+bd create "Title" --type bug       # Create bug report
+bd update <issue-id> --status in_progress
+```
+
+When you discover related issues or future improvements, offer to create beads issues.
+
+## Communication Style
+
+- Explain your debugging process and findings clearly
+- Provide code snippets with context
+- Highlight potential risks or side effects of changes
+- Suggest tests to verify fixes
+- When issues fall outside your scope (infrastructure, deployment), explicitly recommend the infra-ops-manager agent

--- a/.claude/agents/infra-ops-manager.md
+++ b/.claude/agents/infra-ops-manager.md
@@ -1,0 +1,254 @@
+---
+name: infra-ops-manager
+description: Use this agent when managing CI/CD pipelines, debugging infrastructure issues, managing Kubernetes environments, creating or deploying new components, troubleshooting ArgoCD applications, configuring GitOps workflows, or handling environment-specific configurations. This includes tasks like deploying new services, investigating pod failures, managing Helm charts, configuring ArgoCD applications, setting up new environments, or resolving deployment issues.\n\nExamples:\n\n<example>\nContext: User needs to deploy a new service to the development environment.\nuser: "I need to deploy the new notification-service to development"\nassistant: "I'll use the infra-ops-manager agent to handle the deployment of notification-service to the development environment, ensuring we follow the GitOps workflow and create all required components."\n<commentary>\nSince the user is requesting a new service deployment, use the Task tool to launch the infra-ops-manager agent which will create the Helm chart, ArgoCD Application, and manage the GitOps deployment process.\n</commentary>\n</example>\n\n<example>\nContext: User is experiencing pod failures in the development cluster.\nuser: "The api-router pods keep crashing in development"\nassistant: "Let me use the infra-ops-manager agent to investigate the api-router pod crashes and identify the root cause."\n<commentary>\nSince this is an infrastructure debugging issue involving Kubernetes pods, use the Task tool to launch the infra-ops-manager agent to diagnose and resolve the issue.\n</commentary>\n</example>\n\n<example>\nContext: User wants to check the status of ArgoCD applications.\nuser: "Are all our ArgoCD apps synced properly?"\nassistant: "I'll use the infra-ops-manager agent to check the sync status of all ArgoCD applications across environments."\n<commentary>\nSince this involves ArgoCD application management, use the Task tool to launch the infra-ops-manager agent to review application health and sync status.\n</commentary>\n</example>\n\n<example>\nContext: User needs to update environment configuration.\nuser: "We need to update the database connection string for staging"\nassistant: "I'll use the infra-ops-manager agent to properly update the database configuration for the staging environment following our GitOps practices."\n<commentary>\nSince this involves environment configuration management, use the Task tool to launch the infra-ops-manager agent to handle the configuration update through proper GitOps workflow.\n</commentary>\n</example>
+model: sonnet
+color: red
+---
+
+You are a senior DevOps and Infrastructure Engineer specializing in Kubernetes, GitOps, and CI/CD pipelines for the AI-AAS platform. You have deep expertise in ArgoCD, Helm, Kubernetes operations, and cloud infrastructure management.
+
+## Documentation - Your Primary Reference
+
+**CRITICAL**: The `docs/platform/` directory is your source of truth for platform information. Always consult it before searching elsewhere.
+
+### Step 1: Start Here
+**Read `docs/platform/agent-infra-ops-manager.md` first** - This is your navigation index containing:
+- Document index with links to all platform docs
+- Source-of-truth file locations (Helm charts, ArgoCD apps, Terraform configs)
+- Common task workflows (deploying services, debugging pods, fixing ArgoCD)
+- Environment quick reference (branches, kubeconfigs, ingress IPs)
+- Services inventory with namespaces and Helm chart locations
+- Related runbooks for specific procedures
+
+### Step 2: Find the Right Document
+Use the document map to locate specific information:
+
+| Task | Document |
+|------|----------|
+| Cluster access, credentials | `docs/platform/environment-access.md` |
+| Service URLs, endpoints | `docs/platform/endpoints-and-urls.md` |
+| Architecture overview | `docs/platform/infrastructure-overview.md` |
+| CI/CD pipelines | `docs/platform/ci-cd-pipeline.md` |
+| ArgoCD issues | `docs/platform/argocd-testing-guide.md` |
+| TLS/certificates | `docs/platform/tls-ssl-setup.md`, `docs/platform/certificate-architecture.md` |
+| Monitoring, logs | `docs/platform/observability-guide.md` |
+| GitHub Actions | `docs/platform/github-actions-guide.md` |
+
+### Documentation Maintenance Responsibility (MANDATORY)
+
+**You are responsible for keeping `docs/platform/` accurate and current.** This is a core part of your role, not optional.
+
+**ALWAYS update documentation when:**
+1. **Discovering issues or gaps**: Add missing information to the relevant document immediately
+2. **Resolving problems**: Document the solution - future you will thank past you
+3. **Finding outdated information**: Correct it before proceeding with your task
+4. **Creating new infrastructure**: Add new services to `endpoints-and-urls.md`, new credentials to `environment-access.md`
+5. **Changing configurations**: Update all affected docs (endpoints, environment access, services inventory)
+
+**How to update documentation:**
+1. Follow standards in `docs/platform/STANDARDS.md`
+2. **ALWAYS update `last_updated` in frontmatter** to today's date (format: YYYY-MM-DD)
+3. Update `docs/platform/agent-infra-ops-manager.md` if you add new documents or change document purposes
+4. If you cannot complete a documentation update, you MUST create a beads issue:
+   ```bash
+   bd create "Update docs/platform/<filename>.md - <description of what needs updating>" --type task --priority 2
+   ```
+
+**Documentation is part of the task, not separate from it.**
+
+## Core Responsibilities
+
+You manage all infrastructure operations for the AI-AAS platform, including:
+- CI/CD pipeline management and troubleshooting
+- Kubernetes cluster operations and debugging
+- ArgoCD application deployment and synchronization
+- Helm chart creation and maintenance
+- Environment management (development, staging, production)
+- Infrastructure debugging and incident response
+
+## Critical Operating Principles
+
+### 1. GitOps-First Deployment (MANDATORY)
+You MUST follow the GitOps workflow for ALL infrastructure changes:
+1. Make changes locally in the git repository
+2. Test locally with `helm template`, `kubectl diff`, or `make check`
+3. Commit changes: `git add . && git commit -m "description"`
+4. Push to repository: `git push origin <branch>`
+5. ArgoCD syncs automatically (development) or manually sync (production)
+6. Verify deployment with `kubectl get pods` or `argocd app get <app-name>`
+
+**NEVER use `kubectl apply`, `kubectl edit`, or `kubectl patch` for permanent changes.**
+
+### 2. CLI-First Operations
+Always prefer the AI-AAS CLI over direct API calls or kubectl commands:
+```bash
+ai-aas-cli --help                    # See all commands
+ai-aas-cli model --help              # See model commands
+ai-aas-cli status                    # Check system status
+```
+
+### 3. Branch Targeting Rules
+Follow the three-branch promotion workflow:
+- `develop` → development environment (targetRevision: develop)
+- `staging` → staging environment (targetRevision: staging)
+- `main` → production environment (targetRevision: main)
+
+**NEVER reference feature branches in ArgoCD Applications.**
+
+## Service Creation Requirements
+
+When creating a new deployable service, you MUST include:
+
+### 1. Helm Chart at `services/<service-name>/deployments/helm/<service-name>/`:
+- `Chart.yaml` - Chart metadata
+- `values.yaml` - Default values
+- `values-development.yaml` - Development environment values
+- `templates/deployment.yaml` - Deployment with health probes
+- `templates/service.yaml` - Service definition
+- `templates/serviceaccount.yaml` - Service account
+
+### 2. ArgoCD Application at `gitops/clusters/<env>/apps/<service-name>.yaml`
+
+### 3. Health Probes (MANDATORY):
+```yaml
+livenessProbe:
+  httpGet:
+    path: /health
+    port: http
+  initialDelaySeconds: 10
+  periodSeconds: 10
+readinessProbe:
+  httpGet:
+    path: /ready
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 5
+```
+
+## ArgoCD Application Template
+
+Use this template for all new Applications:
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: <service-name>-<environment>
+  namespace: argocd
+  labels:
+    environment: <environment>
+    app: <service-name>
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: platform-<environment>
+  source:
+    repoURL: https://github.com/otherjamesbrown/ai-aas
+    targetRevision: develop  # or staging/main
+    path: services/<service-name>/deployments/helm/<service-name>
+    helm:
+      valueFiles:
+        - values-<environment>.yaml
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: <namespace>
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+      allowEmpty: false
+    syncOptions:
+      - CreateNamespace=true
+      - PrunePropagationPolicy=foreground
+      - PruneLast=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m
+```
+
+## Endpoint URL Management
+
+### Internal Cluster Services (vLLM, Redis, etcd)
+- Use Kubernetes DNS: `service-name.namespace.svc.cluster.local`
+- Define in Helm chart `values-<environment>.yaml` files
+- Avoid inline values in ArgoCD Applications
+
+### External Endpoints (LoadBalancer IPs, Third-party APIs)
+- DO NOT commit to source control
+- Use ConfigMaps created imperatively or external secret management
+
+## Environment Access
+
+Refer to `docs/platform/environment-access.md` for all credentials and access details. The agent document map (`docs/platform/agent-infra-ops-manager.md`) also contains environment quick reference tables.
+
+## Debugging Workflow
+
+When troubleshooting infrastructure issues:
+1. Check pod status: `kubectl get pods -n <namespace>`
+2. Check pod logs: `kubectl logs <pod-name> -n <namespace>`
+3. Check events: `kubectl get events -n <namespace> --sort-by='.lastTimestamp'`
+4. Check ArgoCD sync status: `argocd app get <app-name>`
+5. Verify Helm values: `helm get values <release-name> -n <namespace>`
+6. Check resource definitions: `kubectl describe <resource> <name> -n <namespace>`
+
+## Issue Tracking
+
+Use beads for issue tracking:
+```bash
+bd list --status open              # List open issues
+bd show <issue-id>                 # Show issue details
+bd create "Title" --type bug       # Create new issue
+bd update <issue-id> --status in_progress
+```
+
+Always offer to create beads issues for:
+- Discovered bugs during debugging
+- Infrastructure improvements identified
+- Tasks to be done later
+
+## Quality Assurance
+
+Before completing any infrastructure change:
+1. Verify the change follows GitOps principles
+2. Ensure all required components are created (Helm chart, ArgoCD App, health probes)
+3. Test in development before staging/production
+4. Document any manual steps required
+5. Create beads issues for follow-up work
+
+## Communication Style
+
+- Explain what you're doing and why at each step
+- Provide command outputs and their interpretation
+- Warn about potential impacts before making changes
+- Suggest improvements when you notice infrastructure anti-patterns
+- Always confirm destructive operations before executing
+
+## Task Completion Checklist (MANDATORY)
+
+**Before reporting a task as complete, you MUST run through this checklist:**
+
+### 1. Documentation Validation
+- [ ] Read the relevant `docs/platform/` documents for your task
+- [ ] Verify information in docs matches current reality (check actual endpoints, configs, credentials)
+- [ ] Fix any inaccuracies found - do not leave incorrect documentation
+
+### 2. Documentation Updates
+- [ ] Add any new information discovered during the task
+- [ ] Update `last_updated` field in any modified document frontmatter
+- [ ] If new service created: update `endpoints-and-urls.md` and `agent-infra-ops-manager.md` services inventory
+- [ ] If credentials changed: update `environment-access.md`
+- [ ] If new patterns/procedures: consider adding to relevant guide or creating runbook
+
+### 3. Issue Tracking
+- [ ] Create beads issues for any problems discovered but not fixed
+- [ ] Create beads issues for any documentation gaps you couldn't address
+- [ ] Create beads issues for any improvements identified during the task
+
+### 4. Final Report
+Include in your completion report:
+- What was accomplished
+- What documentation was updated (list files)
+- What beads issues were created (if any)
+- Any follow-up items for the user

--- a/docs/platform/STANDARDS.md
+++ b/docs/platform/STANDARDS.md
@@ -1,0 +1,135 @@
+# Documentation Standards for docs/platform/
+
+**Last Updated**: 2025-12-08
+
+## Purpose
+
+This directory serves as the primary reference for the **infra-ops-manager** AI sub-agent and human operators. Documents must accurately map the project's infrastructure scope, structure, and design.
+
+## Core Principles
+
+### 1. Reference, Don't Duplicate
+
+Point to source-of-truth files rather than copying content that will drift:
+
+```markdown
+<!-- GOOD: Reference the source -->
+Backend endpoints are configured in:
+`services/api-router-service/deployments/helm/api-router-service/values-development.yaml`
+
+<!-- BAD: Duplicating config that will drift -->
+Backend endpoints:
+- vllm-gpt-oss-20b: http://gpt-oss-20b-vllm.system.svc.cluster.local:8000
+- ...
+```
+
+### 2. Source of Truth Locations
+
+| Information Type | Source Location |
+|-----------------|-----------------|
+| Service configurations | `services/<name>/deployments/helm/<name>/values-*.yaml` |
+| ArgoCD applications | `gitops/clusters/<env>/apps/*.yaml` |
+| Infrastructure definitions | `infra/terraform/environments/<env>/` |
+| GitHub workflows | `.github/workflows/*.yml` |
+| Kubernetes resources | Query cluster directly or reference Helm charts |
+| Branching strategy | `docs/development/branching-workflow.md` |
+| Credentials/access | `docs/platform/environment-access.md` (paths only, not values) |
+
+### 3. Verification Commands
+
+For infrastructure state documentation, include commands to verify current state:
+
+```markdown
+## Ingress Configuration
+
+Configured ingresses can be verified with:
+```bash
+kubectl get ingress -A
+```
+
+See `gitops/clusters/development/apps/` for ArgoCD application definitions.
+```
+
+### 4. Document Types
+
+Mark each document with its type in the frontmatter:
+
+| Type | Purpose | Example |
+|------|---------|---------|
+| `reference` | Quick lookup tables, paths, endpoints | environment-access.md |
+| `guide` | How to accomplish tasks | tls-ssl-setup.md |
+| `overview` | Architecture/design explanations | infrastructure-overview.md |
+
+## Required Frontmatter
+
+Every document must include:
+
+```yaml
+---
+title: Document Title
+last_updated: YYYY-MM-DD
+document_type: reference | guide | overview
+---
+```
+
+For documents describing infrastructure state, add:
+
+```yaml
+---
+last_verified: YYYY-MM-DD
+verification_command: "kubectl get ingress -A"
+---
+```
+
+## File Naming
+
+- Use kebab-case: `infrastructure-overview.md`
+- Be descriptive: `ci-cd-pipeline.md` not `ci.md`
+- Group related docs with common prefixes if needed
+
+## Cross-References
+
+When referencing other documentation:
+
+```markdown
+<!-- GOOD: Relative path that can be validated -->
+See [Branching Workflow](../development/branching-workflow.md)
+
+<!-- BAD: Absolute URL that may break -->
+See https://github.com/org/repo/docs/development/branching-workflow.md
+```
+
+## What NOT to Include
+
+1. **Sensitive values** - Reference paths to secrets, not the secrets themselves
+2. **Duplicated config** - Point to Helm values, don't copy them
+3. **Volatile state** - Don't hardcode pod names, IPs that change
+4. **Historical design docs** - Don't reference `specs/` directory (it contains outdated design specs)
+
+## Review Checklist
+
+Before committing documentation changes:
+
+- [ ] Frontmatter includes `last_updated` date
+- [ ] No duplicated configuration (references source files instead)
+- [ ] All file path references are valid
+- [ ] All cross-document links work
+- [ ] Verification commands included where appropriate
+- [ ] Document type is accurate (not design doc masquerading as operational)
+
+## Navigation
+
+**For AI agents**: Start with [agent-infra-ops-manager.md](agent-infra-ops-manager.md) - comprehensive document map with quick navigation, source-of-truth locations, and common task guides.
+
+### Quick Task Reference
+
+| Task | Start With |
+|------|-----------|
+| **Full document map** | [agent-infra-ops-manager.md](agent-infra-ops-manager.md) |
+| Understanding infrastructure | [infrastructure-overview.md](infrastructure-overview.md) |
+| Accessing environments | [environment-access.md](environment-access.md) |
+| Finding endpoints/URLs | [endpoints-and-urls.md](endpoints-and-urls.md) |
+| CI/CD pipeline | [ci-cd-pipeline.md](ci-cd-pipeline.md) |
+| TLS/certificates | [tls-ssl-setup.md](tls-ssl-setup.md), [certificate-architecture.md](certificate-architecture.md) |
+| Observability | [observability-guide.md](observability-guide.md) |
+| GitHub Actions | [github-actions-guide.md](github-actions-guide.md) |

--- a/docs/platform/access-control.md
+++ b/docs/platform/access-control.md
@@ -1,104 +1,75 @@
 # Infrastructure Access Control Guide
 
-**Feature**: `001-infrastructure`  
-**Last Updated**: 2025-11-08  
-**Owner**: Platform Engineering
+---
+last_updated: 2025-12-08
+document_type: guide
+---
 
-## Roles & Responsibilities
+This document covers access control for the AI-AAS platform infrastructure.
 
-| Role | Scope | Capabilities | Approval Required |
-|------|-------|--------------|-------------------|
-| `platform-engineer` | Cluster-wide | Terraform applies, ArgoCD admin, secrets rotation, node scaling | Yes (peer review) |
-| `app-team` | Namespaced (per environment) | Deploy workloads, read metrics/logs, manage namespace-scoped secrets | No (auto on ticket) |
-| `read-only` | Namespaced | `kubectl get` access, Grafana read-only dashboard view | No (manager approval) |
-| `break-glass` | Cluster-wide | Temporary admin access (expires ≤8h) for incidents | Yes (director + incident commander) |
+## Current Access Model
 
-## Access Package Issuance
+### Kubernetes Access
 
-1. Requester submits ticket in `Jira: INFRA-Access` with environment, role, duration.
-2. Platform engineer reviews and runs:
-   ```bash
-   ./scripts/infra/access-package.sh \
-     --env staging \
-     --role app-team \
-     --expires-in 8h \
-     --ticket INFRA-1234
-   ```
-3. Script generates package and uploads artifacts to Linode Object Storage (`access-packages/<env>/<role>/<timestamp>/`).
-4. Signed URLs sent to requester via secure channel (1Password, Slack DM with ephemeral retention).
-5. Audit event stored in Loki label `event=access_package_issued`.
+Access to Kubernetes clusters is managed via kubeconfig files:
 
-## Credential Rotation
+| Environment | Kubeconfig Location |
+|-------------|---------------------|
+| Development | `~/kubeconfigs/kubeconfig-development.yaml` |
+| Staging | `~/kubeconfigs/kubeconfig-staging.yaml` |
+| Production | `~/kubeconfigs/kubeconfig-production.yaml` |
 
-- Default rotation: every 30 days for app-team, every 90 days for read-only, every 7 days for platform-engineer.
-- Execute:
-  ```bash
-  ./scripts/infra/secrets/rotate.sh --env production --role app-team
-  ```
-- Script revokes existing kubeconfig, regenerates certificates, updates Secret Manager, and re-seals Kubernetes secrets.
-- Notify impacted teams using template in `docs/templates/notifications/access-rotation.md` (to be added).
+```bash
+# Access development cluster
+kubectl --kubeconfig=~/kubeconfigs/kubeconfig-development.yaml get pods -A
 
-## Break-Glass Procedure
+# Or set KUBECONFIG
+export KUBECONFIG=~/kubeconfigs/kubeconfig-development.yaml
+kubectl get pods -A
+```
 
-1. Incident commander requests access in `#platform-incident` with ticket reference.
-2. Two-factor confirmation by Director of Platform.
-3. Platform engineer issues package with `--role break-glass --expires-in 4h`.
-4. Access monitored via Kubernetes audit logs and Loki queries (`event=break_glass_action`).
-5. Access automatically revoked at expiration; manual revocation using:
-   ```bash
-   ./scripts/infra/access-package.sh --env production --revoke <package-id>
-   ```
-6. Post-incident review ensures no lingering permissions.
+### ArgoCD Access
 
-## Observability & Alerting for Access
+| Environment | URL | Username |
+|-------------|-----|----------|
+| Development | https://argocd.dev.ai-aas.local | admin |
+| Staging | https://argocd.staging.ai-aas.local | admin |
+| Production | https://argocd.prod.ai-aas.local | admin |
 
-- Alert rule `AccessPackageExpiry` warns 1 hour before expiration (Slack DM to requester + `#platform-infra`).
-- Loki query for monitoring:
-  ```logql
-  {app="access-api"} | json | packageStatus="issued"
-  ```
-- Grafana dashboard `access-overview` tracks active packages, expirations, and rotation status.
+Password retrieval:
+```bash
+kubectl -n argocd get secret argocd-initial-admin-secret -o jsonpath="{.data.password}" | base64 --decode
+```
 
-## Compliance Checklist
+### API Access
 
-- [x] Requests tied to ticket numbers.  
-- [x] All production access requires peer approval.  
-- [x] Break-glass access limited to ≤8 hours.  
-- [x] Rotation schedule documented and automated.  
-- [x] Revocation tested quarterly (SC-007 alignment).
-
-Update this guide whenever roles, durations, or tooling change to keep downstream specs aligned.
+API endpoints require authentication via API keys:
+- API keys are stored in `secrets/env/.env`
+- Use `X-API-Key` header for authentication
+- See [Environment Access](environment-access.md) for details
 
 ## Linode Access Setup
 
-Automation requires API access to Akamai Linode services:
+### Create Personal Access Token
 
-- **Linode Kubernetes Engine (LKE)**: Cluster provisioning (`/lke/clusters`)
-- **Linode Instances**: VM provisioning (`/linode/instances`)
-- **Object Storage**: Metrics bucket management (`/object-storage/buckets`)
-
-## Create Personal Access Token
-
-1. Log into the Akamai Control Panel.
-2. Navigate to **My Profile → API Tokens → Add a Personal Access Token**.
-3. Grant the following permissions:
+1. Log into the Akamai Control Panel
+2. Navigate to **My Profile → API Tokens → Add a Personal Access Token**
+3. Grant permissions:
    - `linodes:read_write`
    - `lke:read_write`
    - `object-storage:read_write`
-4. Copy the generated token and store it securely (e.g., 1Password).
+4. Store token securely (1Password or `secrets/env/.env`)
 
-## Configure Environment
+### Configure Environment
 
 ```bash
 export LINODE_TOKEN=<token>
 export LINODE_DEFAULT_REGION=fr-par
 ```
 
-Store tokens in `.envrc`, `.bash_profile`, or your preferred secret manager. Do **not** commit tokens to Git.
-
 ### Object Storage Credentials
 
-Terraform (and any tooling that uses the S3-compatible backend) needs access/secret keys for Linode Object Storage:
+For Terraform S3-compatible backend:
 
 ```bash
 export LINODE_OBJECT_STORAGE_ACCESS_KEY=<access-key>
@@ -107,14 +78,90 @@ export AWS_ACCESS_KEY_ID=$LINODE_OBJECT_STORAGE_ACCESS_KEY
 export AWS_SECRET_ACCESS_KEY=$LINODE_OBJECT_STORAGE_SECRET_KEY
 ```
 
-We keep these values in `.env` as `LINODE_OBJECT_STORAGE_ACCESS_KEY` / `LINODE_OBJECT_STORAGE_SECRET_KEY`. The Terraform CLI expects the `AWS_*` variables, so export them (or `source .env`) before running `terraform init/plan/apply`.
+Values stored in `secrets/env/.env` as `LINODE_OBJECT_STORAGE_ACCESS_KEY` / `LINODE_OBJECT_STORAGE_SECRET_KEY`.
 
-## CLI Tools
+### CLI Tools
 
-- Official Linode CLI: https://www.linode.com/docs/products/tools/cli/
-- Terraform & Helm charts should use environment variables or secret stores to access tokens.
-- Object Storage commands require a cluster flag (e.g., `--cluster fr-par-1`):  
-  `linode-cli obj ls --cluster fr-par-1 ai-aas/terraform/environments/production`
+- Linode CLI: https://www.linode.com/docs/products/tools/cli/
+- Object Storage commands require cluster flag:
+  ```bash
+  linode-cli obj ls --cluster fr-par-1 ai-aas/terraform/environments/production
+  ```
 
-Refer to `docs/runbooks/linode-setup.md` for full provisioning workflows.
+See [Linode Setup Runbook](../runbooks/linode-setup.md) for provisioning workflows.
 
+## Secrets Management
+
+### Git-Crypt
+
+Sensitive files are encrypted with git-crypt:
+
+```bash
+# Unlock encrypted files
+git-crypt unlock
+
+# Check encryption status
+git-crypt status
+```
+
+### Secret Locations
+
+| Secret Type | Location |
+|-------------|----------|
+| Environment variables | `secrets/env/.env` |
+| Kubeconfigs | `~/kubeconfigs/` |
+| TLS certificates | `infra/secrets/certs/` |
+
+## Security Guidelines
+
+- **NEVER** commit unencrypted credentials to git
+- Rotate credentials regularly
+- Use API keys for service-to-service communication
+- Use OAuth for user authentication
+- Master admin credentials are for emergency access only
+
+## Related Documentation
+
+- [Environment Access](environment-access.md) - Complete credential reference
+- [Linode Setup](../runbooks/linode-setup.md) - Linode provisioning
+- [TLS/SSL Setup](tls-ssl-setup.md) - Certificate management
+
+---
+
+## Planned Features (Not Yet Implemented)
+
+> **Note**: The following sections describe planned access control features that are not yet implemented. Scripts referenced do not exist yet.
+
+### Roles & Responsibilities (Planned)
+
+| Role | Scope | Capabilities |
+|------|-------|--------------|
+| `platform-engineer` | Cluster-wide | Terraform applies, ArgoCD admin, secrets rotation |
+| `app-team` | Namespaced | Deploy workloads, read metrics/logs |
+| `read-only` | Namespaced | kubectl get access, Grafana read-only |
+| `break-glass` | Cluster-wide | Temporary admin access (≤8h) for incidents |
+
+### Access Package Issuance (Planned)
+
+```bash
+# NOT YET IMPLEMENTED
+./scripts/infra/access-package.sh \
+  --env staging \
+  --role app-team \
+  --expires-in 8h \
+  --ticket INFRA-1234
+```
+
+### Credential Rotation (Planned)
+
+```bash
+# NOT YET IMPLEMENTED
+./scripts/infra/secrets/rotate.sh --env production --role app-team
+```
+
+### Break-Glass Procedure (Planned)
+
+1. Incident commander requests access in `#platform-incident`
+2. Two-factor confirmation by Director
+3. Platform engineer issues package with `--role break-glass --expires-in 4h`
+4. Access automatically revoked at expiration

--- a/docs/platform/agent-infra-ops-manager.md
+++ b/docs/platform/agent-infra-ops-manager.md
@@ -1,0 +1,205 @@
+# Infrastructure Operations Manager - Document Map
+
+---
+last_updated: 2025-12-08
+document_type: reference
+purpose: Navigation index for infra-ops-manager AI agent
+---
+
+## Quick Navigation
+
+This document provides a map of all platform documentation to help the infra-ops-manager agent quickly locate relevant information.
+
+## Document Index
+
+### Core Infrastructure
+
+| Document | Purpose | Use When |
+|----------|---------|----------|
+| [infrastructure-overview.md](infrastructure-overview.md) | Architecture, directory structure, components | Understanding overall system design |
+| [environment-access.md](environment-access.md) | Credentials, kubeconfigs, connection strings | Accessing clusters, databases, services |
+| [endpoints-and-urls.md](endpoints-and-urls.md) | All service URLs, ingress status, ports | Finding service endpoints, checking ingress |
+
+### Deployment & CI/CD
+
+| Document | Purpose | Use When |
+|----------|---------|----------|
+| [ci-cd-pipeline.md](ci-cd-pipeline.md) | GitHub Actions, ArgoCD, deployment flow | Understanding CI/CD, fixing pipelines |
+| [argocd-testing-guide.md](argocd-testing-guide.md) | ArgoCD validation, health checks | Debugging ArgoCD sync issues |
+| [github-actions-guide.md](github-actions-guide.md) | Workflow patterns, troubleshooting | Fixing GitHub Actions issues |
+
+### Security & Certificates
+
+| Document | Purpose | Use When |
+|----------|---------|----------|
+| [tls-ssl-setup.md](tls-ssl-setup.md) | Certificate generation, trust setup | TLS issues, certificate problems |
+| [certificate-architecture.md](certificate-architecture.md) | Cert-manager, webhook certs, KServe | Understanding certificate design |
+| [access-control.md](access-control.md) | Kubernetes/ArgoCD access, Linode setup | Understanding access model |
+
+### Observability
+
+| Document | Purpose | Use When |
+|----------|---------|----------|
+| [observability-guide.md](observability-guide.md) | Prometheus, Grafana, Loki, logging | Monitoring issues, log queries |
+| [data-classification.md](data-classification.md) | Data retention, log redaction | Data handling policies |
+
+### Specialized Topics
+
+| Document | Purpose | Use When |
+|----------|---------|----------|
+| [cache-salt-security.md](cache-salt-security.md) | Cache security for vLLM | Model caching security |
+| [ci-remote-cli.md](ci-remote-cli.md) | Remote CI dispatch | Triggering remote CI jobs |
+| [ui-pages.md](ui-pages.md) | Web portal pages, admin CLI | Understanding UI structure |
+
+### Meta Documentation
+
+| Document | Purpose | Use When |
+|----------|---------|----------|
+| [STANDARDS.md](STANDARDS.md) | Documentation standards | Creating/updating docs |
+
+## Key Source-of-Truth Locations
+
+### Infrastructure Configuration
+
+| Information | Location |
+|-------------|----------|
+| Terraform configs | `infra/terraform/environments/<env>/` |
+| ArgoCD applications | `gitops/clusters/<env>/apps/` |
+| ArgoCD projects | `gitops/clusters/<env>/projects/` |
+| Shared Helm charts | `infra/helm/charts/` |
+
+### Service Configuration
+
+| Information | Location |
+|-------------|----------|
+| Service Helm charts | `services/<name>/deployments/helm/<name>/` |
+| Service values (dev) | `services/<name>/deployments/helm/<name>/values-development.yaml` |
+| Service values (staging) | `services/<name>/deployments/helm/<name>/values-staging.yaml` |
+| Web portal Helm | `web/portal/deployments/helm/web-portal/` |
+
+### GitHub Actions
+
+| Information | Location |
+|-------------|----------|
+| All workflows | `.github/workflows/` |
+| Service CI | `.github/workflows/service-ci.yml` |
+| Web portal CI | `.github/workflows/web-portal.yml` |
+| Remote CI dispatch | `.github/workflows/remote-ci.yml` |
+| Branch enforcement | `.github/workflows/branch-flow-enforcement.yml` |
+
+### Credentials & Secrets
+
+| Information | Location |
+|-------------|----------|
+| Kubeconfigs | `~/kubeconfigs/kubeconfig-<env>.yaml` |
+| Self-signed certs | `infra/secrets/certs/` |
+| Environment variables | `secrets/env/.env` |
+
+## Common Tasks - Where to Look
+
+### Deploying a Service
+
+1. Check branch workflow: [ci-cd-pipeline.md](ci-cd-pipeline.md) or `docs/development/branching-workflow.md`
+2. Find Helm chart: `services/<name>/deployments/helm/<name>/`
+3. Check ArgoCD app: `gitops/clusters/<env>/apps/<name>.yaml`
+4. Verify endpoint: [endpoints-and-urls.md](endpoints-and-urls.md)
+
+### Debugging Pod Issues
+
+1. Get cluster access: [environment-access.md](environment-access.md)
+2. Check service config: `services/<name>/deployments/helm/<name>/values-<env>.yaml`
+3. View logs: [observability-guide.md](observability-guide.md)
+4. Check health endpoints: [endpoints-and-urls.md](endpoints-and-urls.md)
+
+### Fixing ArgoCD Sync
+
+1. Understand sync policy: [ci-cd-pipeline.md](ci-cd-pipeline.md)
+2. Check ArgoCD app definition: `gitops/clusters/<env>/apps/`
+3. Troubleshoot: [argocd-testing-guide.md](argocd-testing-guide.md)
+4. Access ArgoCD UI: [environment-access.md](environment-access.md)
+
+### Certificate Issues
+
+1. Understand architecture: [certificate-architecture.md](certificate-architecture.md)
+2. Generate/trust certs: [tls-ssl-setup.md](tls-ssl-setup.md)
+3. Check cert files: `infra/secrets/certs/`
+
+### CI/CD Pipeline Issues
+
+1. Find workflow: `.github/workflows/`
+2. Understand patterns: [github-actions-guide.md](github-actions-guide.md)
+3. Check branch rules: [ci-cd-pipeline.md](ci-cd-pipeline.md)
+
+## Environment Quick Reference
+
+### Development
+
+| Resource | Value |
+|----------|-------|
+| Branch | `develop` |
+| ArgoCD sync | Automated |
+| Kubeconfig | `~/kubeconfigs/kubeconfig-development.yaml` |
+| Ingress IP | `172.232.58.222` |
+| Apps location | `gitops/clusters/development/apps/` |
+
+### Staging
+
+| Resource | Value |
+|----------|-------|
+| Branch | `staging` |
+| ArgoCD sync | Automated |
+| Kubeconfig | `~/kubeconfigs/kubeconfig-staging.yaml` |
+| Apps location | `gitops/clusters/staging/apps/` |
+
+### Production
+
+| Resource | Value |
+|----------|-------|
+| Branch | `main` |
+| ArgoCD sync | Manual |
+| Kubeconfig | `~/kubeconfigs/kubeconfig-production.yaml` |
+| Apps location | `gitops/clusters/production/apps/` |
+
+## Services Inventory
+
+| Service | Namespace | Helm Chart Location |
+|---------|-----------|---------------------|
+| api-router-service | development | `services/api-router-service/deployments/helm/api-router-service/` |
+| user-org-service | user-org-service | `services/user-org-service/deployments/helm/user-org-service/` |
+| analytics-service | development | `services/analytics-service/deployments/helm/analytics-service/` |
+| admin-api-service | admin-api-service | `services/admin-api-service/deployments/helm/admin-api-service/` |
+| web-portal | development | `web/portal/deployments/helm/web-portal/` |
+
+## Verification Commands
+
+```bash
+# Check all ingresses
+kubectl get ingress -A
+
+# Check ArgoCD apps
+kubectl get applications -n argocd
+
+# Check all pods
+kubectl get pods -A
+
+# Check services
+kubectl get svc -A
+
+# View ArgoCD app status
+argocd app list
+
+# Check Helm releases
+helm list -A
+```
+
+## Related Runbooks
+
+| Runbook | Location | Purpose |
+|---------|----------|---------|
+| Linode Setup | `docs/runbooks/linode-setup.md` | Initial Linode/LKE setup |
+| ArgoCD Deployment | `docs/runbooks/argocd-deployment-workflow.md` | Deployment procedures |
+| ArgoCD Bootstrap | `docs/runbooks/argocd-bootstrap.md` | Bootstrap ArgoCD |
+| Infrastructure Rollback | `docs/runbooks/infrastructure-rollback.md` | Rollback procedures |
+| Infrastructure Troubleshooting | `docs/runbooks/infrastructure-troubleshooting.md` | Issue resolution |
+| Deploy to Environments | `docs/runbooks/deploy-to-environments.md` | Environment deployments |
+| Migrations | `docs/runbooks/migrations.md` | Database migrations |

--- a/docs/platform/argocd-testing-guide.md
+++ b/docs/platform/argocd-testing-guide.md
@@ -1,7 +1,9 @@
-# ArgoCD Testing Guide for Beginners
+# ArgoCD Testing Guide
 
-**Last Updated**: 2025-11-16  
-**Audience**: Beginners to ArgoCD
+---
+last_updated: 2025-12-08
+document_type: guide
+---
 
 ## Quick Answer
 

--- a/docs/platform/cache-salt-security.md
+++ b/docs/platform/cache-salt-security.md
@@ -1,6 +1,11 @@
-# Comprehensive Summary: The Use of the `cache_salt` Parameter
+# Cache Salt Security
 
-This document provides a comprehensive summary of the `cache_salt` parameter, explaining its function as a critical security feature designed to overcome the prompt leakage vulnerability inherent in caching systems used by stateless LLMs during inference.
+---
+last_updated: 2025-12-08
+document_type: guide
+---
+
+This document explains the `cache_salt` parameter - a security feature designed to prevent prompt leakage in LLM caching systems.
 
 ## 1. The Fundamental Problem: Statelessness and the Prefill Bottleneck
 
@@ -81,7 +86,7 @@ The `cache_salt` parameter operates within the **Hot Layer** of a multi-tiered m
 
 ## 6. Implementation in AI-AAS Platform
 
-In the AI-AAS platform, `cache_salt` is configured and validated through the load testing harness (see `specs/014-load-testing-harness/spec.md`). The platform supports:
+In the AI-AAS platform, `cache_salt` is configured and validated through the load testing harness. The platform supports:
 
 *   **Organization-level isolation**: Using `org_id` as the cache salt value, allowing cache sharing within an organization while maintaining isolation between organizations.
 
@@ -125,9 +130,8 @@ The `cache_salt` is passed via the `extra_body` parameter in API requests to the
 
 *   **Validation**: The platform includes validation mechanisms to detect and report any cache salt isolation violations, ensuring the security mechanism is functioning correctly.
 
-## References
+## Related Documentation
 
-*   [Load Testing Harness Specification](../specs/014-load-testing-harness/spec.md) - Cache salt configuration and testing
-*   [vLLM Documentation](https://docs.vllm.ai/) - vLLM Automatic Prefix Caching
-*   [API Router vLLM Integration](../API_ROUTER_VLLM_INTEGRATION.md) - Platform integration details
+- [API Router vLLM Integration](../API_ROUTER_VLLM_INTEGRATION.md) - Platform integration details
+- [vLLM Documentation](https://docs.vllm.ai/) - vLLM Automatic Prefix Caching
 

--- a/docs/platform/certificate-architecture.md
+++ b/docs/platform/certificate-architecture.md
@@ -1,5 +1,10 @@
 # Certificate Architecture
 
+---
+last_updated: 2025-12-08
+document_type: overview
+---
+
 This document describes the certificate management architecture for the AI-AAS platform.
 
 ## Overview

--- a/docs/platform/ci-cd-pipeline.md
+++ b/docs/platform/ci-cd-pipeline.md
@@ -1,193 +1,143 @@
 # CI/CD Pipeline
 
-This document provides a comprehensive overview of the CI/CD pipeline, Git strategy, and automated testing for the AI-as-a-Service platform.
+---
+last_updated: 2025-12-08
+document_type: overview
+---
+
+This document provides an overview of the CI/CD pipeline, Git strategy, and automated testing for the AI-as-a-Service platform.
 
 ## Philosophy
 
-Our approach to CI/CD is guided by the principles of GitOps. The `main` branch is the single source of truth, and all changes to the application and its infrastructure are managed through Git. We use a combination of GitHub Actions for Continuous Integration and ArgoCD for Continuous Deployment.
+Our approach to CI/CD is guided by GitOps principles. All changes to the application and infrastructure are managed through Git, with GitHub Actions for Continuous Integration and ArgoCD for Continuous Deployment.
 
 ## Git Strategy
 
-### Branch and Tag Strategy
+> **Source of Truth**: See [Branching Workflow](../development/branching-workflow.md) for complete details.
 
-*   **`main` branch**: The `main` branch represents the latest version of the application and automatically deploys to the **development environment**.
-*   **Feature branches**: All new features and bug fixes are developed on feature branches. These branches are created from `main` and should have a descriptive name (e.g., `feature/new-billing-endpoint`).
-*   **Pull Requests**: When a feature is complete, a pull request is opened to merge the feature branch into `main`. All pull requests must pass the CI pipeline before they can be merged.
-*   **Release Tags**: Production deployments are triggered by creating Git tags following semantic versioning (e.g., `v1.0.0`, `v1.1.0`, `v1.2.3`).
-
-### Environment Promotion Flow
+### Three-Branch Promotion Model
 
 ```
-Feature Branch → main (development) → tag vX.Y.Z (production)
+develop → staging → main
+   ↓         ↓        ↓
+development  staging  production
+(auto-sync)  (auto-sync) (manual)
 ```
 
-1. **Development**: Merge feature branch to `main` → auto-deploys to development
-2. **Production**: Create release tag from `main` → manually sync production apps to tag
+| Branch | Environment | ArgoCD Sync | Purpose |
+|--------|-------------|-------------|---------|
+| `develop` | development | Automated | Fast iteration, immediate feedback |
+| `staging` | staging | Automated | Code review, integration testing |
+| `main` | production | Manual | Production-ready releases |
+
+### Promotion Flow
+
+1. **develop → staging**: PR with code review required
+2. **staging → main**: PR with approval required, production release
+
+Branch protection is enforced via `.github/workflows/branch-flow-enforcement.yml`.
 
 ## Continuous Integration (CI)
 
-Our CI pipeline is powered by GitHub Actions and consists of multiple workflows:
+### Workflow Files
 
-### Go Services CI (`.github/workflows/ci.yml`)
+All CI workflows are in `.github/workflows/`:
 
-The main CI pipeline for Go microservices is triggered on every push to `main` and on every pull request. It consists of the following stages:
+| Workflow | Purpose | Trigger |
+|----------|---------|---------|
+| `service-ci.yml` | Go microservices CI | Push to develop/staging/main, PRs |
+| `web-portal.yml` | Web portal CI (lint, test, e2e, build) | Changes to web/portal/ |
+| `shared-libraries-ci.yml` | Shared Go libraries | Changes to shared/go/ |
+| `dev-environment-ci.yml` | Development environment validation | PRs |
+| `remote-ci.yml` | Remote CI dispatch | Manual/API trigger |
+| `branch-flow-enforcement.yml` | Enforce branch promotion rules | PRs to staging/main |
 
-1.  **Setup & Discover Services**: This stage checks out the code and dynamically discovers all the microservices in the `services/` directory.
-2.  **Build**: This stage compiles the code for each microservice to ensure that it is buildable.
-3.  **Test**: This stage runs the unit and integration tests for each microservice.
-4.  **Lint**: This stage runs a static analysis tool (`golangci-lint`) to check for code quality and style issues.
-5.  **Metrics Upload**: This stage generates and archives build metrics.
+### Go Services CI (`service-ci.yml`)
 
-### Web Portal CI (`.github/workflows/web-portal.yml`)
+Stages:
+1. **Setup & Discover Services** - Dynamically discovers services in `services/`
+2. **Build** - Compiles code for each microservice
+3. **Test** - Runs unit and integration tests
+4. **Lint** - Static analysis via `golangci-lint`
+5. **Metrics Upload** - Archives build metrics
 
-The web portal CI pipeline runs independently and is triggered when changes are made to `web/portal/` or `shared/ts/`. It consists of the following stages:
+### Web Portal CI (`web-portal.yml`)
 
-1.  **Lint**: Runs ESLint to check for code quality and style issues.
-2.  **Unit Tests**: Runs Vitest unit tests to verify component and hook functionality.
-3.  **E2E Tests**: Runs Playwright end-to-end tests to verify user workflows (including critical paths like sign-in).
-4.  **Build**: Builds and pushes Docker images **only if all tests pass**.
+Stages:
+1. **Lint** - ESLint checks
+2. **Unit Tests** - Vitest tests
+3. **E2E Tests** - Playwright end-to-end tests
+4. **Build** - Docker image build **only if all tests pass**
 
-**Critical**: The build stage depends on all test stages passing. This ensures that broken code cannot be deployed, even if it compiles successfully.
+**Critical**: Build depends on all tests passing. Broken code cannot be deployed.
 
 ### Required Secrets
 
-The web portal CI pipeline requires the following GitHub repository secrets:
+See [Environment Access](environment-access.md#github-secrets) for secret configuration.
 
-#### GHCR_TOKEN
-
-**Purpose**: Authentication for pushing Docker images to GitHub Container Registry (GHCR).
-
-**Setup**:
-1. Create a GitHub Personal Access Token (Classic) at https://github.com/settings/tokens/new
-2. Grant the following scopes:
-   - `repo` (Full control of private repositories)
-   - `write:packages` (Upload packages to GitHub Package Registry)
-   - `read:packages` (Download packages from GitHub Package Registry)
-   - `delete:packages` (Optional, for cleanup)
-3. Add the token to repository secrets:
-   ```bash
-   gh secret set GHCR_TOKEN
-   # Paste the token when prompted
-   ```
-
-**Validation**:
-```bash
-# Verify the secret is set
-gh secret list | grep GHCR_TOKEN
-
-# Test GHCR authentication locally
-echo $GHCR_TOKEN | docker login ghcr.io -u <username> --password-stdin
-```
-
-**Troubleshooting**: If the workflow fails with "denied: denied" during Docker login:
-- Token may be expired or revoked - create a new one
-- Token may be missing required scopes - ensure `write:packages` is enabled
-- See `docs/troubleshooting/ci.md` for detailed resolution steps
+Key secrets:
+- `GHCR_TOKEN` - GitHub Container Registry authentication
 
 ## Automated Testing Strategy
 
-We employ a multi-layered testing strategy to ensure the quality and reliability of our platform.
-
-*   **Unit Tests**: These tests verify the functionality of individual components in isolation. They are located alongside the source code and are run as part of the `make test` command.
-*   **Integration Tests**: These tests verify the interaction between different components of the system. They are also run as part of the `make test` command and use Docker to spin up dependencies like databases and message queues.
-*   **End-to-End (E2E) Tests**: These tests verify the functionality of the entire system from the user's perspective.
-*   **Performance Tests**: These tests measure the performance and scalability of the system. They are located in the `tests/perf` directory.
-*   **Infrastructure Tests**: These tests verify the correctness of our infrastructure-as-code. They are located in the `tests/infra` directory.
+| Test Type | Location | Purpose |
+|-----------|----------|---------|
+| Unit Tests | Alongside source code | Individual component verification |
+| Integration Tests | `make test` | Component interaction verification |
+| E2E Tests | `web/portal/e2e/` | Full user workflow verification |
+| Performance Tests | `tests/perf/` | Performance and scalability |
+| Infrastructure Tests | `tests/infra/` | Infrastructure-as-code validation |
 
 ## Continuous Deployment (CD) with ArgoCD
 
-We use ArgoCD to automate the deployment of our application to our Kubernetes clusters. ArgoCD is a declarative, GitOps continuous delivery tool for Kubernetes.
+### GitOps Structure
 
-*   **GitOps Repository**: This repository serves as the single source of truth for our application's desired state. The `gitops/clusters/` directory contains the Kubernetes manifests for each of our environments (`development` and `production`).
-*   **ArgoCD Application**: We have ArgoCD applications configured to monitor this repository for changes.
-
-### Deployment Process by Environment
-
-#### Development Environment
-
-**Trigger**: Merge to `main` branch
-
-1.  The CI pipeline runs and **validates all tests pass** (unit, integration, E2E, linting).
-2.  **Only if tests pass**, new container images are built for the services that have changed.
-3.  ArgoCD detects that the `main` branch has changed.
-4.  ArgoCD **automatically syncs** the changes to the development Kubernetes cluster.
-
-**Configuration**: Development apps watch `main` branch with `automated` sync enabled.
-
-#### Production Environment
-
-**Trigger**: Git tag creation (e.g., `v1.0.0`)
-
-1.  Create a release tag using the release script: `./scripts/dev/release.sh v1.0.0`
-2.  CI pipeline builds and pushes production Docker images tagged with the version.
-3.  ArgoCD detects the new tag is available.
-4.  **Manual sync required**: Run `argocd app sync <app-name> --revision v1.0.0`
-5.  ArgoCD deploys the tagged version to the production Kubernetes cluster.
-
-**Configuration**: Production apps watch `v*` tags with manual sync (`automated: null`).
-
-### Creating a Production Release
-
-Use the provided release script to create and push a release tag:
-
-```bash
-# Create a release
-./scripts/dev/release.sh v1.0.0 "Initial production release"
-
-# The script will:
-# 1. Validate version format (vMAJOR.MINOR.PATCH)
-# 2. Check you're on main branch
-# 3. Show what's included in the release
-# 4. Create and push an annotated Git tag
-# 5. Provide next steps for deployment
-
-# After the tag is pushed, manually sync production:
-argocd app sync user-org-service-production --revision v1.0.0
+```
+gitops/
+├── clusters/
+│   ├── development/    # Watches: develop branch
+│   │   ├── apps/       # ArgoCD Application definitions
+│   │   └── projects/   # AppProject definitions
+│   ├── staging/        # Watches: staging branch
+│   │   ├── apps/
+│   │   └── projects/
+│   └── production/     # Watches: main branch
+│       ├── apps/
+│       └── projects/
 ```
 
-**Semantic Versioning Guidelines:**
-- **MAJOR** (v2.0.0): Breaking changes, incompatible API changes
-- **MINOR** (v1.1.0): New features, backwards-compatible
-- **PATCH** (v1.0.1): Bug fixes, backwards-compatible
+### Deployment by Environment
 
-**Important**: ArgoCD validates Kubernetes resources and deployment health, but **does not run application tests**. All testing must pass in CI before code reaches ArgoCD. This ensures that broken functionality (like a broken sign-in button) cannot be deployed, even if the code compiles successfully.
+#### Development
+- **Trigger**: Push to `develop` branch
+- **Process**: CI validates → ArgoCD auto-syncs
+- **Apps location**: `gitops/clusters/development/apps/`
 
-## Branch Protection
+#### Staging
+- **Trigger**: PR merge from `develop` to `staging`
+- **Process**: CI validates → ArgoCD auto-syncs
+- **Apps location**: `gitops/clusters/staging/apps/`
 
-To ensure broken code cannot be merged, configure branch protection rules for the `main` branch:
+#### Production
+- **Trigger**: PR merge from `staging` to `main`
+- **Process**: CI validates → Manual ArgoCD sync required
+- **Apps location**: `gitops/clusters/production/apps/`
 
-1. Go to repository Settings → Branches
-2. Add branch protection rule for `main`
-3. Enable "Require status checks to pass before merging"
-4. Select required checks:
-   - `lint` (web-portal)
-   - `test` (web-portal)
-   - `test-e2e` (web-portal)
-   - Other service CI checks as needed
-
-This ensures that PRs cannot be merged unless all CI checks pass, preventing broken code from reaching production.
-
-## GitOps & ArgoCD
-
-- GitOps repository structure resides under `gitops/`.
-- Bootstrap ArgoCD per cluster with `./scripts/gitops/bootstrap_argocd.sh <environment> <kube-context>`.
-- Register this repository using `argocd repo add` and sync `platform-<env>-infrastructure` applications after each promotion.
-- Customize `gitops/templates/argocd-values.yaml` (ingress, service type, RBAC) and rerun the bootstrap script to apply changes.
+```bash
+# Manual production sync
+argocd app sync <app-name>
+```
 
 ### ArgoCD Application Standards
 
-All ArgoCD Applications MUST follow these standards for consistency and reliability:
-
-#### Required Sync Policy
-
-Every Application MUST include these sync options:
+All Applications MUST include:
 
 ```yaml
 syncPolicy:
   automated:
-    prune: true        # Remove resources not in Git
-    selfHeal: true     # Revert manual changes
-    allowEmpty: false  # Prevent accidental deletion
+    prune: true
+    selfHeal: true
+    allowEmpty: false
   syncOptions:
     - CreateNamespace=true
     - PrunePropagationPolicy=foreground
@@ -202,29 +152,42 @@ syncPolicy:
 
 #### Branch Targeting
 
-- **Development apps**: Target `develop` branch (`targetRevision: develop`)
-- **Production apps**: Target `main` branch (`targetRevision: main`)
-- **Never** reference feature branches or deleted branches in Applications
+| Environment | targetRevision |
+|-------------|---------------|
+| development | `develop` |
+| staging | `staging` |
+| production | `main` |
 
-#### RBAC Projects
+**Never** reference feature branches in Applications.
 
-Applications MUST be assigned to an AppProject with restrictive policies:
+### Bootstrap & Configuration
 
-- **Explicit namespace destinations**: Never use wildcard `*` for namespaces
-- **Explicit sourceRepos**: Only allow specific repository URLs
-- **clusterResourceWhitelist**: Only allow required cluster-scoped resources (Namespaces, CRDs, ClusterRoles, etc.)
-- **namespaceResourceBlacklist**: Block dangerous resources like ResourceQuota/LimitRange
+```bash
+# Bootstrap ArgoCD for an environment
+./scripts/gitops/bootstrap_argocd.sh <environment> <kube-context>
 
-Example project structure in `gitops/clusters/<env>/projects/platform-project.yaml`.
+# Customize via
+gitops/templates/argocd-values.yaml
+```
 
-#### Application Locations
+## Branch Protection
 
-- Development: `gitops/clusters/development/apps/<service-name>.yaml`
-- Production: `gitops/clusters/production/apps/<service-name>.yaml`
-- Projects: `gitops/clusters/<env>/projects/`
+Configure in GitHub Settings → Branches:
 
-### Related Documentation
+### For `staging`:
+- Require PR before merging
+- Require 1 approval
+- Require status check: `check-source-branch`
 
-- `docs/runbooks/argocd-deployment-workflow.md` - Deployment workflow
-- `docs/runbooks/argocd-bootstrap.md` - Bootstrap procedures
-- `docs/platform/argocd-testing-guide.md` - Testing guide
+### For `main`:
+- Require PR before merging
+- Require 1 approval
+- Require status check: `check-source-branch`
+
+## Related Documentation
+
+- [Branching Workflow](../development/branching-workflow.md) - Complete branch promotion details
+- [ArgoCD Deployment Workflow](../runbooks/argocd-deployment-workflow.md)
+- [ArgoCD Bootstrap](../runbooks/argocd-bootstrap.md)
+- [ArgoCD Testing Guide](argocd-testing-guide.md)
+- [Environment Access](environment-access.md)

--- a/docs/platform/ci-remote-cli.md
+++ b/docs/platform/ci-remote-cli.md
@@ -1,5 +1,10 @@
 # CI Remote CLI Usage
 
+---
+last_updated: 2025-12-08
+document_type: guide
+---
+
 `make ci-remote` wraps GitHub Actions workflow_dispatch to run the full automation pipeline from restricted machines.
 
 ## Prerequisites
@@ -8,7 +13,7 @@
    ```bash
    gh auth login --scopes repo,workflow
    ```
-2. Ensure `GH_HOST` and default repo are set if using enterprise instances:
+2. Set default repo if using enterprise instances:
    ```bash
    gh repo set-default otherjamesbrown/ai-aas
    ```
@@ -19,37 +24,61 @@
 make ci-remote SERVICE=user-org-service REF=$(git rev-parse HEAD) NOTES="Smoke test"
 ```
 
-- `SERVICE`: Optional; defaults to `all`. Pass a specific service to scope build/test matrices.
-- `REF`: Git ref to run (defaults to current HEAD). Useful when testing PR branches.
-- `NOTES`: Appended to workflow run summary for auditing.
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `SERVICE` | Service to build/test | `all` |
+| `REF` | Git ref to run | Current HEAD |
+| `NOTES` | Run summary for auditing | (empty) |
+
+## Output
 
 The command prints:
-
 1. Workflow dispatch confirmation
 2. Actions run URL
-3. Final status summary when the workflow completes
+3. Final status summary when workflow completes
 
 ## Exit Codes
 
-- `0`: Workflow finished successfully.
-- `1`: Dispatch failed (invalid auth, missing workflow).
-- `2`: Workflow completed but reported failure (inspect the Actions log).
+| Code | Meaning |
+|------|---------|
+| `0` | Workflow finished successfully |
+| `1` | Dispatch failed (auth, missing workflow) |
+| `2` | Workflow completed but reported failure |
 
 ## Environment Variables
 
-| Variable | Purpose |
-|----------|---------|
-| `CI_REMOTE_WORKFLOW` | Override workflow filename (default `ci-remote.yml`). |
-| `GH_API_TOKEN` | Use a specific PAT instead of the authenticated CLI session. |
-| `CI_REMOTE_WAIT` | Set to `false` to dispatch and exit immediately without waiting. |
+| Variable | Purpose | Default |
+|----------|---------|---------|
+| `CI_REMOTE_WORKFLOW` | Override workflow filename | `remote-ci.yml` |
+| `GH_API_TOKEN` | Use specific PAT instead of CLI session | (CLI auth) |
+| `CI_REMOTE_WAIT` | Set to `false` to exit without waiting | `true` |
+
+## Examples
+
+```bash
+# Run all services on current branch
+make ci-remote
+
+# Run specific service
+make ci-remote SERVICE=api-router-service
+
+# Run on specific ref
+make ci-remote SERVICE=user-org-service REF=feature-branch
+
+# With audit note
+make ci-remote SERVICE=web-portal NOTES="Pre-release validation"
+```
 
 ## Troubleshooting
 
 If `workflow_dispatch` doesn't create runs:
-1. Ensure the workflow exists on the `main` branch
+
+1. Ensure `remote-ci.yml` exists on `main` branch
 2. Check for workflow syntax errors in GitHub Actions UI
-3. See `docs/troubleshooting/ci-remote-dispatch.md` for detailed resolution
-4. Review `docs/platform/github-actions-guide.md` for common pitfalls
+3. Verify authentication: `gh auth status`
+4. Review [GitHub Actions Guide](github-actions-guide.md) for common pitfalls
 
-For other CI issues, see `docs/troubleshooting/ci.md`.
+## Related Documentation
 
+- [GitHub Actions Guide](github-actions-guide.md) - Workflow patterns and troubleshooting
+- [CI/CD Pipeline](ci-cd-pipeline.md) - Overall pipeline architecture

--- a/docs/platform/data-classification.md
+++ b/docs/platform/data-classification.md
@@ -1,7 +1,9 @@
-# Data Classification & Retention for Development Environments
+# Data Classification & Retention
 
-**Last Updated**: 2025-01-20  
-**Applies To**: Local and remote development workspaces
+---
+last_updated: 2025-12-08
+document_type: guide
+---
 
 ## Overview
 
@@ -250,19 +252,12 @@ This document defines data classification levels and retention policies for arti
 - Secrets detected in logs (pattern matching)
 - Audit log failures
 
-## References
+## Related Documentation
 
-- `configs/log-redaction.yaml` - Log redaction patterns
-- `scripts/dev/vector-agent.toml` - Vector agent configuration
-- `specs/002-local-dev-environment/` - Development environment specification
-- `specs/011-observability/` - Observability and logging specification
+- [Observability Guide](observability-guide.md) - Monitoring and logging
+- [Environment Access](environment-access.md) - Credentials and access
 
-## Updates
+---
 
-This policy is reviewed and updated as needed. Last update: 2025-01-20
-
-Changes:
-- Initial version: Defines classification levels and retention for dev environments
-- Integrates with remote workspace TTL enforcement
-- Aligns with observability stack requirements
+*Last updated: 2025-12-08*
 

--- a/docs/platform/endpoints-and-urls.md
+++ b/docs/platform/endpoints-and-urls.md
@@ -1,458 +1,283 @@
-# Endpoints and URLs Configuration Guide
+# Endpoints and URLs
+
+---
+last_updated: 2025-12-08
+last_verified: 2025-12-08
+document_type: reference
+verification_command: "kubectl get ingress -A"
+---
 
 ## Overview
 
-This document identifies all endpoints that need to be exposed with consistent URLs and SSL certificates across development and production environments.
+This document lists all exposed endpoints in the platform. URLs use two domain patterns:
+- `.ai-aas.local` - For local development (requires hosts file entry)
+- `.otherjamesbrown.com` - Public DNS (nip.io fallback available)
 
-**Access Pattern**: Local DNS (hosts file) + Self-signed SSL certificates  
-**Security**: Firewall-restricted access (no VPN required)  
-**DNS**: Managed via `/etc/hosts` (Linux/macOS) or `C:\Windows\System32\drivers\etc\hosts` (Windows)
+**Ingress IP**: `172.232.58.222` (development cluster)
 
-## Quick Reference
+## Quick Reference - Development Environment
 
-### API Router Service Endpoints
+| Service | URL | Status |
+|---------|-----|--------|
+| API Router | `https://api.dev.ai-aas.local` | ✅ Active |
+| Web Portal | `https://portal.dev.ai-aas.local` | ✅ Active |
+| User-Org Service | `https://user-org.dev.ai-aas.local` | ✅ Active |
+| Analytics Service | `https://analytics.dev.ai-aas.local` | ✅ Active |
+| Admin API | `https://admin-api.dev.ai-aas.local` | ✅ Active |
+| Grafana | `https://grafana.dev.ai-aas.local` | ✅ Active |
+| Loki | `https://loki.dev.ai-aas.local` | ✅ Active |
+| ArgoCD | `https://argocd.dev.ai-aas.local` | ✅ Active |
+| etcd | `https://etcd.dev.ai-aas.local` | ✅ Active |
 
-**Base URL**: `https://api.dev.ai-aas.local` (dev) / `https://api.prod.ai-aas.local` (prod)
+## Verification
 
-| Endpoint | Method | Description | Auth |
-|----------|--------|-------------|------|
-| `/v1/inference` | POST | Custom inference endpoint | API Key |
-| `/v1/chat/completions` | POST | OpenAI-compatible chat completions | API Key |
-| `/v1/completions` | POST | OpenAI-compatible text completions | API Key |
-| `/v1/status/healthz` | GET | Health check | None |
-| `/v1/status/readyz` | GET | Readiness check | None |
+```bash
+# List all ingresses
+kubectl get ingress -A
 
-**Authentication**: All inference endpoints require an API key via `X-API-Key` header.
-
-## Endpoint Categories
-
-### 1. Application Services (Microservices)
-
-These are the core application services that need external access:
-
-#### API Router Service (Gateway)
-- **Purpose**: Main API gateway for all API requests
-- **Port**: 8080 (HTTP)
-- **Health**: `/v1/status/healthz`, `/v1/status/readyz`
-- **API Paths**: 
-  - `/v1/inference` - Custom inference endpoint (requires API key)
-  - `/v1/chat/completions` - OpenAI-compatible chat completions endpoint (requires API key)
-  - `/v1/completions` - OpenAI-compatible text completions endpoint (requires API key)
-- **Current Dev URL**: `api.dev.ai-aas.local` (via ingress)
-- **Current Prod URL**: `api.prod.ai-aas.local` (via ingress)
-- **Ingress**: ✅ Configured
-- **TLS**: ✅ Configured with cert-manager
-- **Authentication**: API key via `X-API-Key` header
-
-#### User-Org Service
-- **Purpose**: User and organization management, authentication
-- **Port**: 8081 (HTTP), 8443 (HTTPS admin)
-- **Health**: `/healthz`
-- **API Paths**: `/v1/auth/*`, `/v1/orgs/*`, `/v1/users/*`
-- **Current URL**: Not exposed via ingress (internal only)
-- **Ingress**: ❌ Not configured
-- **TLS**: ❌ Not configured
-- **Note**: Currently accessed internally or via API router
-
-#### Analytics Service
-- **Purpose**: Analytics, usage metrics, reliability data, exports
-- **Port**: 8084 (HTTP)
-- **Health**: `/analytics/v1/status/healthz`, `/analytics/v1/status/readyz`
-- **API Paths**: `/analytics/v1/orgs/{orgId}/usage`, `/analytics/v1/orgs/{orgId}/reliability`, `/analytics/v1/orgs/{orgId}/exports`
-- **Current URL**: Not exposed via ingress (internal only)
-- **Ingress**: ❌ Not configured
-- **TLS**: ❌ Not configured
-- **Note**: Currently accessed internally or via API router
-
-#### Web Portal (Frontend)
-- **Purpose**: React/TypeScript web UI
-- **Port**: 80 (HTTP), 5173 (dev)
-- **Health**: `/` (root)
-- **Current Dev URL**: `portal.ai-aas.dev` (from values.yaml)
-- **Current Prod URL**: Not explicitly set (should mirror dev pattern)
-- **Ingress**: ✅ Configured
-- **TLS**: ✅ Configured with cert-manager (Let's Encrypt staging in dev)
-
-### 2. Observability Stack
-
-These are monitoring and observability tools that operators need to access:
-
-#### Grafana
-- **Purpose**: Dashboards, metrics visualization, log exploration
-- **Port**: 3000 (HTTP)
-- **Health**: `/api/health`
-- **Current URL**: Not exposed via ingress (port-forward only)
-- **Ingress**: ❌ Not configured
-- **TLS**: ❌ Not configured
-- **Access Pattern**: Currently via `kubectl port-forward` or internal cluster access
-- **Recommended URLs**:
-  - Dev: `grafana.dev.ai-aas.dev` or `grafana.dev.ai-aas.internal`
-  - Prod: `grafana.prod.ai-aas.prod` or `grafana.prod.ai-aas.internal`
-- **Note**: May want internal-only access (`.internal` domain) or VPN-only access
-
-#### Prometheus
-- **Purpose**: Metrics collection and querying
-- **Port**: 9090 (HTTP)
-- **Health**: `/-/healthy`
-- **Current URL**: Not exposed via ingress (internal only)
-- **Ingress**: ❌ Not configured
-- **TLS**: ❌ Not configured
-- **Access Pattern**: Typically internal-only, accessed via Grafana
-- **Recommended URLs**:
-  - Dev: `prometheus.dev.ai-aas.internal` (internal only)
-  - Prod: `prometheus.prod.ai-aas.internal` (internal only)
-- **Note**: Usually kept internal for security
-
-#### Loki
-- **Purpose**: Log aggregation
-- **Port**: 3100 (HTTP)
-- **Health**: `/ready`
-- **Current URL**: Not exposed via ingress (internal only)
-- **Ingress**: ❌ Not configured
-- **TLS**: ❌ Not configured
-- **Access Pattern**: Internal-only, accessed via Grafana
-- **Note**: Typically kept internal
-
-### 3. GitOps & Infrastructure
-
-#### ArgoCD
-- **Purpose**: GitOps deployment management
-- **Port**: 8080 (HTTP), 443 (HTTPS)
-- **Health**: `/healthz`
-- **Current URL**: Not exposed via ingress (port-forward only)
-- **Ingress**: ❌ Disabled in `gitops/templates/argocd-values.yaml` (`server.ingress.enabled: false`)
-- **TLS**: ❌ Not configured
-- **Access Pattern**: Currently via `kubectl port-forward` or `scripts/access-argocd-ui.sh`
-- **Recommended URLs**:
-  - Dev: `argocd.dev.ai-aas.dev` or `argocd.dev.ai-aas.internal`
-  - Prod: `argocd.prod.ai-aas.prod` or `argocd.prod.ai-aas.internal`
-- **Note**: Should be internal-only or VPN-protected for security
-
-### 4. Optional/Internal Services
-
-These may not need external URLs but are worth documenting:
-
-#### MinIO Console
-- **Purpose**: S3-compatible object storage management UI
-- **Port**: 9001 (HTTP)
-- **Current URL**: Not exposed via ingress (internal only)
-- **Ingress**: ❌ Not configured
-- **TLS**: ❌ Not configured
-- **Note**: Typically kept internal
-
-## Recommended URL Structure
-
-### Local DNS Approach (Using /etc/hosts)
-
-Since we're using local DNS via hosts file and self-signed certificates, we'll use a consistent domain pattern that works locally:
-
-### Development Environment
-
-```
-# Application Services
-api.dev.ai-aas.local        → API Router Service (gateway)
-portal.dev.ai-aas.local     → Web Portal (frontend)
-
-# Observability
-grafana.dev.ai-aas.local    → Grafana
-prometheus.dev.ai-aas.local → Prometheus (optional, usually accessed via Grafana)
-
-# GitOps
-argocd.dev.ai-aas.local     → ArgoCD
+# Check specific service
+curl -k https://api.dev.ai-aas.local/v1/status/healthz
 ```
 
-### Production Environment
+## Application Services
 
+### API Router Service (Gateway)
+
+| Property | Value |
+|----------|-------|
+| Purpose | Main API gateway for inference requests |
+| Namespace | `development` |
+| Port | 8080 |
+| Ingress | ✅ Configured |
+| TLS | ✅ Configured |
+
+**URLs**:
+- `https://api.dev.ai-aas.local`
+- `https://api.dev.otherjamesbrown.com`
+
+**Endpoints**:
+| Path | Method | Auth | Description |
+|------|--------|------|-------------|
+| `/v1/chat/completions` | POST | API Key | OpenAI-compatible chat |
+| `/v1/completions` | POST | API Key | OpenAI-compatible completions |
+| `/v1/inference` | POST | API Key | Custom inference |
+| `/v1/status/healthz` | GET | None | Health check |
+| `/v1/status/readyz` | GET | None | Readiness check |
+
+**Configuration**: `services/api-router-service/deployments/helm/api-router-service/values-development.yaml`
+
+### User-Org Service
+
+| Property | Value |
+|----------|-------|
+| Purpose | User and organization management |
+| Namespace | `user-org-service` |
+| Port | 8081 |
+| Ingress | ✅ Configured |
+| TLS | ✅ Configured |
+
+**URLs**:
+- `https://user-org.dev.ai-aas.local`
+- `https://user-org.dev.otherjamesbrown.com`
+
+**Endpoints**:
+| Path | Description |
+|------|-------------|
+| `/v1/auth/*` | Authentication |
+| `/v1/orgs/*` | Organization management |
+| `/v1/users/*` | User management |
+| `/healthz` | Health check |
+
+**Configuration**: `services/user-org-service/deployments/helm/user-org-service/values-development.yaml`
+
+### Analytics Service
+
+| Property | Value |
+|----------|-------|
+| Purpose | Usage metrics and analytics |
+| Namespace | `development` |
+| Port | 8084 |
+| Ingress | ✅ Configured |
+| TLS | ✅ Configured |
+
+**URLs**:
+- `https://analytics.dev.ai-aas.local`
+- `https://analytics.dev.otherjamesbrown.com`
+
+**Endpoints**:
+| Path | Description |
+|------|-------------|
+| `/analytics/v1/orgs/{orgId}/usage` | Usage data |
+| `/analytics/v1/orgs/{orgId}/reliability` | Reliability metrics |
+| `/analytics/v1/orgs/{orgId}/exports` | Data exports |
+| `/analytics/v1/status/healthz` | Health check |
+
+**Configuration**: `services/analytics-service/deployments/helm/analytics-service/values-development.yaml`
+
+### Admin API Service
+
+| Property | Value |
+|----------|-------|
+| Purpose | Administrative operations |
+| Namespace | `admin-api-service` |
+| Ingress | ✅ Configured |
+| TLS | ✅ Configured |
+
+**URLs**:
+- `https://admin-api.dev.ai-aas.local`
+- `https://admin-api.dev.otherjamesbrown.com`
+
+**Configuration**: `services/admin-api-service/deployments/helm/admin-api-service/values-development.yaml`
+
+### Web Portal
+
+| Property | Value |
+|----------|-------|
+| Purpose | React/TypeScript web UI |
+| Namespace | `development` |
+| Port | 80 |
+| Ingress | ✅ Configured |
+| TLS | ✅ Configured |
+
+**URLs**:
+- `https://portal.dev.ai-aas.local`
+- `https://portal.dev.otherjamesbrown.com`
+
+**Configuration**: `web/portal/deployments/helm/web-portal/values-development.yaml`
+
+## Observability Stack
+
+### Grafana
+
+| Property | Value |
+|----------|-------|
+| Purpose | Dashboards and visualization |
+| Namespace | `monitoring` |
+| Port | 3000 |
+| Ingress | ✅ Configured |
+| TLS | ✅ Configured |
+
+**URLs**:
+- `https://grafana.dev.ai-aas.local`
+- `https://grafana.dev.otherjamesbrown.com`
+- `http://grafana.172.232.58.222.nip.io` (fallback)
+
+**Configuration**: `gitops/clusters/development/apps/` (kube-prometheus-stack)
+
+### Loki
+
+| Property | Value |
+|----------|-------|
+| Purpose | Log aggregation |
+| Namespace | `monitoring` |
+| Port | 3100 |
+| Ingress | ✅ Configured |
+| TLS | ✅ Configured |
+
+**URLs**:
+- `https://loki.dev.ai-aas.local`
+- `https://loki.dev.otherjamesbrown.com`
+
+**Configuration**: `gitops/clusters/development/apps/` (loki application)
+
+### Prometheus
+
+| Property | Value |
+|----------|-------|
+| Purpose | Metrics collection |
+| Namespace | `monitoring` |
+| Port | 9090 |
+| Ingress | Internal only |
+
+Access via Grafana or port-forward:
+```bash
+kubectl port-forward -n monitoring svc/kube-prometheus-stack-prometheus 9090:9090
 ```
-# Application Services
-api.prod.ai-aas.local       → API Router Service (gateway)
-portal.prod.ai-aas.local    → Web Portal (frontend)
 
-# Observability
-grafana.prod.ai-aas.local   → Grafana
-prometheus.prod.ai-aas.local → Prometheus (optional, usually accessed via Grafana)
+## Infrastructure Services
 
-# GitOps
-argocd.prod.ai-aas.local    → ArgoCD
-```
+### ArgoCD
 
-**Note**: Using `.local` TLD is a common convention for local development. You can use any domain you prefer (e.g., `ai-aas.dev`, `ai-aas.internal`, `localhost.localdomain`).
+| Property | Value |
+|----------|-------|
+| Purpose | GitOps deployment |
+| Namespace | `argocd` |
+| Ingress | ✅ Configured |
+| TLS | ✅ Configured |
+
+**URL**: `https://argocd.dev.ai-aas.local`
+
+**Configuration**: `gitops/templates/argocd-values.yaml`
+
+### etcd
+
+| Property | Value |
+|----------|-------|
+| Purpose | Distributed key-value store |
+| Namespace | `development` |
+| Ingress | ✅ Configured |
+| TLS | ✅ Configured |
+
+**URLs**:
+- `https://etcd.dev.ai-aas.local`
+- `https://etcd.dev.otherjamesbrown.com`
+
+## Local DNS Setup
 
 ### Hosts File Entries
 
-You'll need to add entries like this to your hosts file, pointing to your ingress load balancer IP:
+Add to `/etc/hosts` (Linux/macOS) or `C:\Windows\System32\drivers\etc\hosts` (Windows):
 
 ```
-# Development Environment
-<INGRESS_IP>  api.dev.ai-aas.local
-<INGRESS_IP>  portal.dev.ai-aas.local
-<INGRESS_IP>  grafana.dev.ai-aas.local
-<INGRESS_IP>  argocd.dev.ai-aas.local
-
-# Production Environment
-<INGRESS_IP>  api.prod.ai-aas.local
-<INGRESS_IP>  portal.prod.ai-aas.local
-<INGRESS_IP>  grafana.prod.ai-aas.local
-<INGRESS_IP>  argocd.prod.ai-aas.local
+# AI-AAS Development Environment
+172.232.58.222  api.dev.ai-aas.local
+172.232.58.222  portal.dev.ai-aas.local
+172.232.58.222  user-org.dev.ai-aas.local
+172.232.58.222  analytics.dev.ai-aas.local
+172.232.58.222  admin-api.dev.ai-aas.local
+172.232.58.222  grafana.dev.ai-aas.local
+172.232.58.222  loki.dev.ai-aas.local
+172.232.58.222  argocd.dev.ai-aas.local
+172.232.58.222  etcd.dev.ai-aas.local
 ```
 
-Replace `<INGRESS_IP>` with your actual ingress controller's external IP address.
-
-## SSL Certificate Requirements
-
-### Self-Signed Certificates
-
-Since we're using local DNS and firewall-restricted access, we'll use **self-signed certificates** for all endpoints:
-
-- ✅ API Router Service (gateway)
-- ✅ Web Portal
-- ✅ Grafana
-- ✅ ArgoCD
-- ✅ Prometheus (if exposed)
-
-### Certificate Setup
-
-1. **Generate a self-signed CA** (Certificate Authority)
-2. **Create certificates** for each domain signed by the CA
-3. **Trust the CA** on your local machine(s)
-4. **Configure Kubernetes secrets** with the certificates
-5. **Update ingress** to use the certificate secrets
-
-This approach provides:
-- ✅ Encrypted HTTPS connections
-- ✅ No public DNS required
-- ✅ No VPN required (firewall handles access)
-- ✅ Consistent URLs across environments
-- ⚠️ Browser warnings until CA is trusted (one-time setup)
-
-## Implementation Checklist
-
-### Phase 1: Application Services (Priority: P1)
-- [ ] Configure consistent URLs for API Router Service in dev and prod
-- [ ] Configure consistent URLs for Web Portal in dev and prod
-- [ ] Set up SSL certificates via cert-manager for both services
-- [ ] Update environment profiles with URL configurations
-- [ ] Test HTTPS redirects and certificate validity
-
-### Phase 2: Observability (Priority: P2)
-- [ ] Decide on access pattern (public vs internal-only)
-- [ ] Configure Grafana ingress with TLS
-- [ ] Optionally expose Prometheus (recommend internal-only)
-- [ ] Set up VPN or network policies for internal access
-
-### Phase 3: GitOps (Priority: P2)
-- [ ] Configure ArgoCD ingress (recommend internal-only)
-- [ ] Set up TLS certificates
-- [ ] Configure authentication/authorization
-- [ ] Update access scripts
-
-### Phase 4: Additional Services (Priority: P3)
-- [ ] Review if User-Org Service needs direct external access
-- [ ] Review if Analytics Service needs direct external access
-- [ ] Configure MinIO Console if needed (recommend internal-only)
-
-## Local DNS Configuration (Hosts File)
-
-### Finding Your Ingress IP
-
-First, get your ingress controller's external IP:
+### Automation Script
 
 ```bash
-# For Kubernetes
-kubectl get svc -n ingress-nginx ingress-nginx-controller
-
-# Or for Linode NodeBalancer
-kubectl get svc -n ingress-nginx ingress-nginx-controller -o jsonpath='{.status.loadBalancer.ingress[0].ip}'
+# Auto-update hosts file
+sudo ./scripts/infra/update-hosts-file.sh
 ```
 
-### Updating Hosts File
+## TLS Certificates
 
-#### Linux/macOS
+Self-signed certificates are used for development. See:
+- Certificate files: `infra/secrets/certs/`
+- Setup guide: [TLS/SSL Setup](tls-ssl-setup.md)
 
-Edit `/etc/hosts` (requires sudo):
-
+To trust the CA:
 ```bash
-sudo nano /etc/hosts
-# or
-sudo vim /etc/hosts
-```
-
-Add entries:
-```
-# Development Environment
-<INGRESS_IP>  api.dev.ai-aas.local
-<INGRESS_IP>  portal.dev.ai-aas.local
-<INGRESS_IP>  grafana.dev.ai-aas.local
-<INGRESS_IP>  argocd.dev.ai-aas.local
-
-# Production Environment
-<INGRESS_IP>  api.prod.ai-aas.local
-<INGRESS_IP>  portal.prod.ai-aas.local
-<INGRESS_IP>  grafana.prod.ai-aas.local
-<INGRESS_IP>  argocd.prod.ai-aas.local
-```
-
-#### Windows
-
-Edit `C:\Windows\System32\drivers\etc\hosts` (run Notepad as Administrator):
-
-1. Open Notepad as Administrator
-2. File → Open → `C:\Windows\System32\drivers\etc\hosts`
-3. Add the same entries as above
-4. Save
-
-### Verifying DNS Resolution
-
-```bash
-# Test DNS resolution
-ping api.dev.ai-aas.local
-nslookup api.dev.ai-aas.local
-
-# Test HTTPS (will show cert warning until CA is trusted)
-curl -k https://api.dev.ai-aas.local/healthz
-```
-
-## Security Considerations
-
-### Firewall-Restricted Access
-
-Since access is restricted via firewall to your machine:
-- ✅ No VPN required
-- ✅ No public DNS required
-- ✅ Self-signed certificates are acceptable
-- ✅ All endpoints can be exposed via ingress
-
-### Authentication
-
-- **Grafana**: Should have authentication enabled (OAuth, LDAP, or basic auth)
-- **ArgoCD**: Already has authentication (admin password + RBAC)
-- **Prometheus**: Consider basic auth or network policies
-- **API Router**: Uses API keys and OAuth (already implemented)
-
-### Certificate Trust
-
-After generating self-signed certificates:
-1. **Trust the CA certificate** on your local machine(s)
-2. **Browsers will show warnings** until CA is trusted
-3. **One-time setup** per machine that needs access
-
-## Next Steps
-
-1. **Generate self-signed certificates**: Use the provided script to create CA and certificates
-2. **Create Kubernetes secrets**: Store certificates as Kubernetes secrets
-3. **Update hosts file**: Add entries pointing to ingress IP
-4. **Update Helm values**: Configure ingress with TLS secrets
-5. **Trust CA certificate**: Install CA on your local machine(s)
-6. **Test**: Verify HTTPS access and certificate validity
-7. **Update environment profiles**: Add URL configurations to `configs/environments/*.yaml`
-8. **Document**: Update runbooks and quickstart guides with new URLs
-
-## Implementation Scripts
-
-See the following scripts for automation:
-- `scripts/infra/generate-self-signed-certs.sh` - Generate CA and certificates
-- `scripts/infra/update-hosts-file.sh` - Update hosts file with ingress IP
-- `scripts/infra/create-tls-secrets.sh` - Create Kubernetes TLS secrets
-
-## Quick Start Guide
-
-### Step 1: Generate Certificates
-
-```bash
-# Generate CA and certificates for all endpoints
-./scripts/infra/generate-self-signed-certs.sh
-```
-
-This creates:
-- `infra/secrets/certs/ai-aas-ca.crt` - CA certificate (trust this)
-- `infra/secrets/certs/ai-aas-ca.key` - CA private key (keep secure)
-- `infra/secrets/certs/tls.crt` - TLS certificate for all domains
-- `infra/secrets/certs/tls.key` - TLS private key
-
-### Step 2: Trust CA Certificate
-
-**Linux (Debian/Ubuntu):**
-```bash
-sudo cp infra/secrets/certs/ai-aas-ca.crt /usr/local/share/ca-certificates/ai-aas-ca.crt
+# Linux (Debian/Ubuntu)
+sudo cp infra/secrets/certs/ai-aas-ca.crt /usr/local/share/ca-certificates/
 sudo update-ca-certificates
-```
 
-**macOS:**
-```bash
+# macOS
 sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain infra/secrets/certs/ai-aas-ca.crt
 ```
 
-**Windows:**
-1. Open `infra/secrets/certs/ai-aas-ca.crt`
-2. Click "Install Certificate"
-3. Choose "Local Machine" → "Place all certificates in the following store"
-4. Browse → Select "Trusted Root Certification Authorities"
-5. Click OK and Finish
+## Finding Ingress Configuration
 
-### Step 3: Create Kubernetes Secrets
+| Service | Helm Values Location |
+|---------|---------------------|
+| API Router | `services/api-router-service/deployments/helm/api-router-service/values-*.yaml` |
+| User-Org | `services/user-org-service/deployments/helm/user-org-service/values-*.yaml` |
+| Analytics | `services/analytics-service/deployments/helm/analytics-service/values-*.yaml` |
+| Admin API | `services/admin-api-service/deployments/helm/admin-api-service/values-*.yaml` |
+| Web Portal | `web/portal/deployments/helm/web-portal/values-*.yaml` |
+| ArgoCD | `gitops/templates/argocd-values.yaml` |
+| Observability | `gitops/clusters/<env>/apps/` |
 
-```bash
-# Create TLS secret in default namespace
-./scripts/infra/create-tls-secrets.sh
+## Related Documentation
 
-# Or specify namespace
-./scripts/infra/create-tls-secrets.sh --namespace ingress-nginx
-```
-
-### Step 4: Update Hosts File
-
-```bash
-# Auto-detect ingress IP and update hosts file
-sudo ./scripts/infra/update-hosts-file.sh
-
-# Or specify IP manually
-sudo ./scripts/infra/update-hosts-file.sh --ingress-ip 192.168.1.100
-```
-
-### Step 5: Configure Ingress
-
-Update your Helm values to use the TLS secret:
-
-```yaml
-ingress:
-  enabled: true
-  className: nginx
-  annotations:
-    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
-  hosts:
-    - host: api.dev.ai-aas.local
-      paths:
-        - path: /
-          pathType: Prefix
-  tls:
-    - secretName: ai-aas-tls  # Secret created in step 3
-      hosts:
-        - api.dev.ai-aas.local
-        - portal.dev.ai-aas.local
-        - grafana.dev.ai-aas.local
-        - argocd.dev.ai-aas.local
-        # ... add all domains
-```
-
-### Step 6: Test
-
-```bash
-# Test DNS resolution
-ping api.dev.ai-aas.local
-
-# Test HTTPS (should work without -k flag after trusting CA)
-curl https://api.dev.ai-aas.local/healthz
-
-# Open in browser (should not show certificate warning)
-open https://portal.dev.ai-aas.local
-```
-
-## References
-
-- Ingress TLS Spec: `specs/013-ingress-tls/spec.md`
-- Infrastructure Overview: `docs/platform/infrastructure-overview.md`
-- API Router Values: `services/api-router-service/deployments/helm/api-router-service/values*.yaml`
-- Web Portal Values: `web/portal/deployments/helm/web-portal/values*.yaml`
-- ArgoCD Values: `gitops/templates/argocd-values.yaml`
-- Component Registry: `configs/components.yaml`
-
+- [Environment Access](environment-access.md) - Credentials and kubeconfig setup
+- [TLS/SSL Setup](tls-ssl-setup.md) - Certificate configuration
+- [Infrastructure Overview](infrastructure-overview.md) - Architecture overview

--- a/docs/platform/environment-access.md
+++ b/docs/platform/environment-access.md
@@ -1,5 +1,10 @@
 # Environment Access Guide
 
+---
+last_updated: 2025-12-08
+document_type: reference
+---
+
 This document provides quick access information for all environments and services in the AI-AAS platform.
 
 ## Important Note on Credentials
@@ -243,11 +248,11 @@ psql -h ${DATABASE_HOST} -p ${DATABASE_PORT} -U ${DATABASE_USER} -d ${DATABASE_N
 - Use OAuth for user authentication
 - Master admin credentials are for emergency access only
 
-## References
+## Related Documentation
 
-- GitOps Workflow: `docs/runbooks/argocd-deployment-workflow.md`
-- Database Setup: `docs/runbooks/migrations.md`
-- Infrastructure: `docs/platform/infrastructure-overview.md`
-- Service Deployment: `docs/runbooks/deploy-to-environments.md`
-- Debugging with Logs: `docs/ai-assistant/debugging-with-logs.md`
-- Observability Overview: `docs/platform/observability.md`
+- [Infrastructure Overview](infrastructure-overview.md) - Architecture and directory structure
+- [Endpoints and URLs](endpoints-and-urls.md) - All service endpoints
+- [Observability Guide](observability-guide.md) - Monitoring, logging, dashboards
+- [ArgoCD Deployment Workflow](../runbooks/argocd-deployment-workflow.md) - Deployment procedures
+- [Database Migrations](../runbooks/migrations.md) - Database setup
+- [Deploy to Environments](../runbooks/deploy-to-environments.md) - Environment deployments

--- a/docs/platform/github-actions-guide.md
+++ b/docs/platform/github-actions-guide.md
@@ -1,119 +1,116 @@
 # GitHub Actions Workflow Guide
 
-This guide documents best practices and common pitfalls when working with GitHub Actions workflows in this repository.
+---
+last_updated: 2025-12-08
+document_type: guide
+---
 
-## Directory Structure
+This guide documents best practices and common pitfalls when working with GitHub Actions workflows.
 
-```
-.github/workflows/
-├── ci.yml                    # Main CI on push/PR (Go services)
-├── web-portal.yml           # Web portal CI (lint, test, e2e, build)
-├── ci-remote.yml            # Manual dispatch workflow
-├── reusable-build.yml       # Reusable workflow for build/test
-└── (other workflows)
-```
+## Workflow Files
 
-**CRITICAL**: Reusable workflows MUST be at the top level of `.github/workflows/`. GitHub does not support subdirectories for reusable workflows.
+All workflows are in `.github/workflows/`. Current workflows:
+
+| Workflow | Purpose |
+|----------|---------|
+| `service-ci.yml` | Go microservices CI (build, test, lint) |
+| `web-portal.yml` | Web portal CI (lint, test, e2e, build) |
+| `shared-libraries-ci.yml` | Shared Go libraries CI |
+| `shared-libraries-release.yml` | Shared libraries release |
+| `dev-environment-ci.yml` | Development environment validation |
+| `remote-ci.yml` | Manual dispatch workflow |
+| `reusable-build.yml` | Reusable workflow for build/test |
+| `branch-flow-enforcement.yml` | Enforce branch promotion rules |
+| `api-router-validation.yml` | API router specific validation |
+| `branch-sync-check.yml` | Branch synchronization checks |
+| `db-guardrails.yml` | Database migration guardrails |
+| `e2e.yml` | End-to-end tests |
+| `infra-availability.yml` | Infrastructure availability checks |
+| `infra-terraform.yml` | Terraform validation |
+| `post-deploy-health-check.yml` | Post-deployment health checks |
+
+**Note**: Reusable workflows MUST be at top level of `.github/workflows/`. GitHub doesn't support subdirectories.
 
 ## Common Pitfalls & Solutions
 
 ### 1. Reusable Workflow Paths
 
-❌ **WRONG** - Subdirectories don't work:
 ```yaml
+# WRONG - Subdirectories don't work
 uses: ./.github/workflows/reusable/build.yml  # Will fail!
-```
 
-✅ **CORRECT** - Top-level only:
-```yaml
+# CORRECT - Top-level only
 uses: ./.github/workflows/reusable-build.yml
 ```
 
-**Error Message**: `invalid value workflow reference: workflows must be defined at the top level`
-
 ### 2. Environment Context in Reusable Workflows
 
-❌ **WRONG** - `env` context not available in workflow call parameters:
 ```yaml
-jobs:
-  build:
-    uses: ./.github/workflows/reusable-build.yml
-    with:
-      go-version: ${{ env.GO_VERSION }}  # Will fail!
+# WRONG - env context not available in workflow call parameters
+with:
+  go-version: ${{ env.GO_VERSION }}  # Will fail!
+
+# CORRECT - Use hardcoded values
+with:
+  go-version: "1.21.x"
 ```
-
-✅ **CORRECT** - Use hardcoded values or pass via inputs:
-```yaml
-env:
-  GO_VERSION: "1.21.x"
-
-jobs:
-  build:
-    uses: ./.github/workflows/reusable-build.yml
-    with:
-      go-version: "1.21.x"  # Hardcoded in call
-```
-
-**Note**: The `env` context IS available within job steps, just not in the `with:` parameters of a workflow call.
-
-**Error Message**: `Unrecognized named-value: 'env'`
 
 ### 3. Job Dependencies and Outputs
 
-❌ **WRONG** - Missing dependency declaration:
 ```yaml
-jobs:
-  info:
-    outputs:
-      service: ${{ steps.collect.outputs.service }}
-  
-  test:
-    needs: build  # Only depends on build
-    steps:
-      - run: echo ${{ needs.info.outputs.service }}  # Can't access!
-```
+# WRONG - Can't access outputs from jobs not in needs
+test:
+  needs: build  # Only depends on build
+  steps:
+    - run: echo ${{ needs.info.outputs.service }}  # Can't access!
 
-✅ **CORRECT** - Declare all dependencies:
-```yaml
-jobs:
-  info:
-    outputs:
-      service: ${{ steps.collect.outputs.service }}
-  
-  test:
-    needs: [build, info]  # Explicitly list all dependencies
-    steps:
-      - run: echo ${{ needs.info.outputs.service }}  # Now accessible
+# CORRECT - Declare all dependencies
+test:
+  needs: [build, info]  # Explicitly list all dependencies
+  steps:
+    - run: echo ${{ needs.info.outputs.service }}
 ```
-
-**Rule**: If a job references another job's outputs via `needs.jobname.outputs.*`, that `jobname` MUST be in the `needs:` list.
 
 ### 4. workflow_dispatch on Feature Branches
 
-**Issue**: `workflow_dispatch` requires the workflow file to exist on the default branch (`main`) before it can be triggered on feature branches.
-
-**Solution**: Merge workflow files to `main` first, then you can dispatch them on any branch.
+`workflow_dispatch` requires the workflow file to exist on `main` before it can be triggered on feature branches.
 
 ```bash
-# This works once workflow exists on main
-gh workflow run ci-remote.yml --ref feature-branch -f service=my-service
+# Works once workflow exists on main
+gh workflow run remote-ci.yml --ref feature-branch -f service=my-service
 ```
 
 ### 5. Script Permissions
 
-**Issue**: Scripts checked out in Actions don't preserve executable permissions.
-
-✅ **CORRECT** - Always set executable bit in git:
 ```bash
+# Set executable bit in git
 chmod +x scripts/metrics/upload.sh
 git add scripts/metrics/upload.sh
-git commit -m "Make script executable"
+
+# Or invoke with explicit interpreter
+bash ./scripts/metrics/upload.sh
 ```
 
-Or invoke with explicit interpreter:
+## Test Before Build Pattern
+
+The web portal workflow demonstrates the critical pattern:
+
 ```yaml
-- run: bash ./scripts/metrics/upload.sh
+jobs:
+  lint:
+    # Run linting
+
+  test:
+    # Run unit tests
+
+  test-e2e:
+    # Run E2E tests
+
+  build:
+    needs: [lint, test, test-e2e]  # Build ONLY if all tests pass
 ```
+
+**Why This Matters**: Without this dependency, broken code could be deployed if it compiles. Always make build/deploy jobs depend on test jobs.
 
 ## Testing Workflows
 
@@ -124,11 +121,11 @@ make ci-local SERVICE=hello-service
 
 ### Remote Testing
 ```bash
-# Test on feature branch (after workflow exists on main)
+# Use make target
 make ci-remote SERVICE=world-service NOTES="testing fix"
 
-# Or use gh CLI directly
-gh workflow run ci-remote.yml --ref $(git branch --show-current) \
+# Or gh CLI directly
+gh workflow run remote-ci.yml --ref $(git branch --show-current) \
   -f service=hello-service \
   -f notes="manual test"
 ```
@@ -136,7 +133,7 @@ gh workflow run ci-remote.yml --ref $(git branch --show-current) \
 ### Debugging Failed Runs
 ```bash
 # View run details
-gh run list --workflow ci-remote.yml -L 5
+gh run list --workflow remote-ci.yml -L 5
 gh run view RUN_ID
 
 # View failed logs
@@ -146,113 +143,51 @@ gh run view RUN_ID --log-failed
 gh run watch RUN_ID
 ```
 
-## Web Portal Workflow Pattern
-
-The web portal workflow (`.github/workflows/web-portal.yml`) demonstrates a critical pattern: **test before build**.
-
-```yaml
-jobs:
-  lint:
-    name: Lint
-    # Runs ESLint
-  
-  test:
-    name: Unit Tests
-    # Runs Vitest unit tests
-  
-  test-e2e:
-    name: E2E Tests
-    # Runs Playwright E2E tests (including critical user workflows)
-  
-  build:
-    name: Build and Push Docker Image
-    needs: [lint, test, test-e2e]  # ⚠️ CRITICAL: Build depends on all tests
-    # Only builds if all tests pass
-```
-
-**Why This Matters**: Without this dependency, broken code (like a non-functional sign-in button) could be deployed if it compiles successfully. By making `build` depend on test jobs, we ensure:
-- ✅ All tests must pass before building images
-- ✅ Broken functionality cannot reach production
-- ✅ PRs are blocked if tests fail
-
-**Best Practice**: Always make build/deploy jobs depend on test jobs. Never build or deploy code that hasn't passed all tests.
-
 ## Workflow Design Patterns
 
-### Pattern: Dispatch Info Collection
+### Dispatch Info Collection
 ```yaml
 jobs:
   dispatch-info:
-    runs-on: ubuntu-latest
     outputs:
       service: ${{ steps.collect.outputs.service }}
     steps:
       - id: collect
-        run: |
-          SERVICE="${{ inputs.service }}"
-          if [ -z "$SERVICE" ]; then
-            SERVICE="all"
-          fi
-          echo "service=$SERVICE" >> "$GITHUB_OUTPUT"
+        run: echo "service=${{ inputs.service || 'all' }}" >> "$GITHUB_OUTPUT"
 ```
 
-### Pattern: Reusable Workflow Call
+### Reusable Workflow Call
 ```yaml
 jobs:
   build:
-    needs: dispatch-info  # Declare dependency
+    needs: dispatch-info
     uses: ./.github/workflows/reusable-build.yml
     with:
       service: ${{ needs.dispatch-info.outputs.service }}
-      target: build
       go-version: "1.21.x"  # Hardcoded, not from env
 ```
 
-### Pattern: Conditional Execution
+### Conditional Execution
 ```yaml
 jobs:
   metrics:
     needs: [lint, dispatch-info]
     if: ${{ always() }}  # Run even if previous jobs fail
-    runs-on: ubuntu-latest
 ```
-
-### Pattern: Test Before Build (Critical)
-```yaml
-jobs:
-  lint:
-    # Run linting
-  
-  test:
-    # Run unit tests
-  
-  test-e2e:
-    # Run E2E tests
-  
-  build:
-    needs: [lint, test, test-e2e]  # Build only if all tests pass
-    # Build and push Docker image
-```
-
-**Rule**: Never build or deploy without running tests first. Always use `needs:` to enforce test dependencies.
 
 ## Troubleshooting Checklist
 
 When `workflow_dispatch` doesn't create runs:
 
-1. ✓ Is the workflow file on the default branch (`main`)?
-2. ✓ Are all reusable workflows at top level of `.github/workflows/`?
-3. ✓ Are job dependencies correctly declared in `needs:`?
-4. ✓ Is `env` context used only in job steps, not workflow call parameters?
-5. ✓ Are scripts executable (`chmod +x`)?
-6. ✓ Check GitHub UI for syntax errors (Actions tab → workflow → "invalid workflow file")
+1. Is the workflow file on `main` branch?
+2. Are reusable workflows at top level of `.github/workflows/`?
+3. Are job dependencies correctly declared in `needs:`?
+4. Is `env` context used only in job steps, not workflow call parameters?
+5. Are scripts executable (`chmod +x`)?
+6. Check GitHub UI for syntax errors (Actions tab)
 
-See `docs/troubleshooting/ci-remote-dispatch.md` for detailed resolution of a real incident.
+## Related Documentation
 
-## References
-
+- [CI/CD Pipeline](ci-cd-pipeline.md) - Overall pipeline architecture
+- [CI Remote CLI](ci-remote-cli.md) - Remote dispatch usage
 - [GitHub Actions Documentation](https://docs.github.com/en/actions)
-- [Reusable Workflows](https://docs.github.com/en/actions/using-workflows/reusing-workflows)
-- [Workflow Syntax](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions)
-- [Contexts](https://docs.github.com/en/actions/learn-github-actions/contexts)
-

--- a/docs/platform/infrastructure-overview.md
+++ b/docs/platform/infrastructure-overview.md
@@ -1,113 +1,139 @@
 # Infrastructure Architecture Overview
 
-**Feature**: `001-infrastructure`  
-**Last Updated**: 2025-11-08  
-**Owner**: Platform Engineering
+---
+last_updated: 2025-12-08
+document_type: overview
+---
 
 ## High-Level Architecture
 
-- **Provider**: Akamai Linode Kubernetes Engine (LKE) in `fr-par` (configurable via `default_region` / `region_overrides` in Terraform).
-- **Environments**: `development`, `staging`, `production`, `system` share a single control plane with dedicated namespaces and resource quotas.
-- **Node Pools**:
-  - Baseline: `g6-standard-8` (3–6 nodes per environment, autoscaling to 10).
-  - GPU (system): `g1-gpu-rtx6000` (2 nodes) reserved for vLLM workloads.
-- **Networking**:
-  - Calico NetworkPolicies implement default-deny stance.
-  - Ingress via NGINX Ingress Controller + cert-manager (Let's Encrypt for production).
-  - Self-signed certificates for local development (see `infra/secrets/certs/README.md`).
-  - External DNS records served through Linode DNS (production) or local hosts file (development).
-- **GitOps**:
-  - Terraform provisions clusters, networking, secrets scaffolding.
-  - ArgoCD reconciles Helm charts (`infra/helm/charts/*`), including observability, ingress, and sample service.
+- **Provider**: Akamai Linode Kubernetes Engine (LKE) in `fr-par` region
+- **Environments**: `development`, `staging`, `production` (separate clusters)
+- **GitOps**: ArgoCD reconciles Helm charts from this repository
+
+## Directory Structure
+
+```
+infra/
+├── terraform/
+│   └── environments/
+│       ├── _shared/          # Shared Terraform modules
+│       ├── development/      # Development cluster config
+│       ├── staging/          # Staging cluster config
+│       ├── production/       # Production cluster config
+│       └── system/           # Shared system components
+├── secrets/
+│   ├── certs/               # Self-signed certificates for local dev
+│   └── README.md
+└── helm/
+    └── charts/              # Shared Helm charts (ingress configs)
+
+gitops/
+└── clusters/
+    ├── development/         # ArgoCD apps for development
+    │   ├── apps/            # Application definitions
+    │   └── projects/        # AppProject definitions
+    ├── staging/             # ArgoCD apps for staging
+    │   ├── apps/
+    │   └── projects/
+    └── production/          # ArgoCD apps for production
+        ├── apps/
+        └── projects/
+
+services/
+├── admin-api-service/       # Admin API
+├── admin-cli/               # Admin CLI tool
+├── ai-aas-cli/              # Platform CLI
+├── analytics-service/       # Analytics
+├── api-router-service/      # API routing/gateway
+├── user-org-service/        # User & org management
+└── _template/               # Service template
+```
+
+## Node Pools
+
+| Pool Type | Instance Type | Purpose |
+|-----------|--------------|---------|
+| Baseline | `g6-standard-8` | General workloads |
+| GPU | `g1-gpu-rtx6000` | vLLM/ML workloads |
+
+Node pool configuration is in Terraform: `infra/terraform/environments/<env>/`
+
+## Networking
+
+- **Ingress**: NGINX Ingress Controller + cert-manager
+- **TLS**: Let's Encrypt (production), self-signed (development)
+- **Network Policies**: Calico with default-deny stance
+- **DNS**:
+  - Production: Linode DNS
+  - Development: Local hosts file (`.ai-aas.local` domains)
 
 ## Change Management Flow
 
-1. **Plan**: Contributor opens PR modifying `infra/terraform` or `infra/helm`.
-2. **Validation**: GitHub Actions runs `terraform fmt/validate/plan`, `tflint`, `tfsec`, Terratest, and Helm lint.
-3. **Approval**: Production changes require two approvals plus environment protection.
+1. **PR**: Modify files in `infra/terraform/`, `gitops/`, or `services/*/deployments/helm/`
+2. **Validation**: GitHub Actions runs lint, validate, plan
+3. **Approval**: Required for production changes
 4. **Apply**:
-   - Terraform: `make -C infra/terraform apply ENV=<env>` executed by GitHub Actions with OIDC.
-   - ArgoCD: Syncs Git changes automatically (production gated via manual `argocd app sync`).
-5. **Verification**: Automated smoke tests deploy sample service and confirm metrics/alerts.
-6. **Audit**: Every change emits audit events to Loki (`infra_change_applied`) and posts summary to `#platform-infra`.
+   - **Terraform**: `make -C infra/terraform apply ENV=<env>`
+   - **ArgoCD**: Auto-sync (dev/staging) or manual sync (production)
+5. **Verification**: Health checks validate deployment
 
 ## Secrets & Access
 
-- Linode Secret Manager is source-of-truth. Secret bundles defined under `infra/secrets/bundles/*.yaml`.
-- Sealed Secrets controller encrypts bundle payloads; ArgoCD applies manifests per environment.
-- Access packages described in `specs/001-infrastructure/contracts/environment-access.md`. Packages expire within 24 hours and require Slack request logged in `#platform-access`.
+- **Sealed Secrets**: Encrypts secrets for GitOps
+- **Certificate Storage**: `infra/secrets/certs/`
+- **Access Setup**: See [Environment Access](environment-access.md)
 
 ## Observability Stack
 
-- **Prometheus/Grafana**: `kube-prometheus-stack` with environment-tagged dashboards.
-- **Logs**: Loki with tenant per environment; Tempo enabled for tracing (optional by environment).
-- **Alert Routing**: Alertmanager routes to Slack (`#platform-infra` primary, `#platform-pager` on-call).
-- **Dashboards**: Overview dashboards named `<env>-overview`, stored under Grafana UID `env-<env>`.
+| Component | Purpose | Namespace |
+|-----------|---------|-----------|
+| Prometheus | Metrics collection | `observability` |
+| Grafana | Dashboards | `observability` |
+| Loki | Log aggregation | `observability` |
+| Alertmanager | Alert routing | `observability` |
 
-## Sample Service Validation
+Configuration: `gitops/clusters/<env>/apps/` (kube-prometheus-stack, loki applications)
 
-- Helm chart: `infra/helm/charts/sample-service`.
-- Validates ingress, secrets mount, metrics emission, and alert pipeline.
-- Terratest pipeline asserts:
-  - Deployment becomes `Available` within 5 minutes.
-  - `/healthz` endpoint returns 200.
-  - Prometheus scrape discovers `sample_service_up` metric.
-
-## Compliance & Auditing
-
-- Terraform state stored in Linode Object Storage bucket `ai-aas` (path `terraform/environments/<env>/terraform.tfstate`). Export `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` from the `.env` entries (`LINODE_OBJECT_STORAGE_ACCESS_KEY`, `LINODE_OBJECT_STORAGE_SECRET_KEY`) before running Terraform so the backend is accessible.
-- Drift detection job (`scripts/infra/drift-detect.sh`) runs hourly; severity `major` opens incident automatically.
-- ArgoCD application events forward to Loki (label `argo_app`).
-- Quarterly controls: secrets rotation check, rollback drill (SC-007), alert simulation.
+See [Observability Guide](observability-guide.md) for details.
 
 ## TLS/SSL Certificates
 
-### Production
-- **Let's Encrypt**: Automatic certificate issuance and renewal via cert-manager
-- **DNS**: Public DNS records required for Let's Encrypt validation
-- **Ingress**: NGINX Ingress Controller with TLS termination
+| Environment | Method | Details |
+|-------------|--------|---------|
+| Production | Let's Encrypt | Automatic via cert-manager |
+| Development | Self-signed | See `infra/secrets/certs/` |
 
-### Local Development
-- **Self-Signed Certificates**: CA and TLS certificates in `infra/secrets/certs/`
-- **Local DNS**: Hosts file entries for `.ai-aas.local` domains
-- **Firewall-Restricted**: Access limited to authorized machines (no VPN required)
-- **Setup**: See `infra/secrets/certs/README.md` for certificate generation and trust instructions
+Setup instructions: [TLS/SSL Setup](tls-ssl-setup.md)
 
-## Dependencies
+## Terraform State
 
-- `docs/platform/linode-access.md`: Token creation and CLI setup.
-- `docs/platform/access-control.md`: Detailed RBAC and package issuance procedures.
-- `docs/platform/observability-guide.md`: Dashboard conventions, alert tuning.
-- `docs/platform/endpoints-and-urls.md`: Complete endpoint and URL configuration guide.
-- `docs/platform/tls-ssl-setup.md`: TLS/SSL certificate setup and management.
-- `docs/runbooks/infrastructure-rollback.md`: Step-by-step rollback instructions.
-- `docs/runbooks/infrastructure-troubleshooting.md`: Issue resolution catalog.
-- `infra/secrets/certs/README.md`: Self-signed certificate setup and management.
+State is stored in Linode Object Storage:
+- Bucket: `ai-aas`
+- Path: `terraform/environments/<env>/terraform.tfstate`
 
-Keep this document updated alongside infrastructure changes to ensure context for downstream specs (`005-user-org-service`, `010-vllm-deployment`, `011-observability`).
+Generated artifacts are written to: `infra/terraform/environments/<env>/.generated/`
 
-## Capacity Validation
+## Related Documentation
 
-- Terraform module `infra/terraform/modules/lke-cluster/quotas.tf` defines per-environment quotas supporting 30 services.  
-- Performance harness `tests/infra/perf/capacity_test.go` deploys placeholder workloads to verify scheduling and HPA thresholds.  
-- Record results and tuning notes in this guide after each significant scaling event.
+### Platform Docs
+- [Environment Access](environment-access.md) - Credentials and access setup
+- [Endpoints and URLs](endpoints-and-urls.md) - Service endpoints
+- [TLS/SSL Setup](tls-ssl-setup.md) - Certificate management
+- [Observability Guide](observability-guide.md) - Monitoring and logging
+- [CI/CD Pipeline](ci-cd-pipeline.md) - Deployment workflow
 
-## Cluster Inventory
+### Runbooks
+- [Linode Setup](../runbooks/linode-setup.md) - Linode CLI and token setup
+- [Infrastructure Rollback](../runbooks/infrastructure-rollback.md) - Rollback procedures
+- [Infrastructure Troubleshooting](../runbooks/infrastructure-troubleshooting.md) - Issue resolution
 
-- **Development**: LKE cluster `531921`, kubeconfig context `lke531921-ctx`. GitHub secrets: `DEV_KUBECONFIG_B64`, `DEV_KUBE_CONTEXT`.
-- **Production**: LKE cluster `531922`, kubeconfig context `lke531922-ctx`. GitHub secrets: `PROD_KUBECONFIG_B64`, `PROD_KUBE_CONTEXT`.
-- **Staging/System**: Defined in Terraform for future rollout; keep configuration in sync but defer `terraform apply` until post-launch objectives require additional environments.
-- Kubeconfigs are stored in 1Password and replicated into GitHub Actions secrets for automation (availability probes, scripted applies).
+### Source of Truth Locations
 
-## Generated Artifacts
-
-- Terraform renders manifests into `infra/generated/<environment>/` for GitOps promotion.
-- Running Terraform per environment writes manifests and values into `infra/terraform/environments/<env>/.generated/`:
-  - Network policies and firewall specs (`network/`).
-  - Sealed secrets bootstrap manifests (`secrets/`).
-  - Observability values overlays (`observability/`).
-  - ArgoCD ApplicationSet manifests (`argo/`).
-- Copy the contents into `infra/generated/<environment>/` (already committed) and promote those files into the GitOps repository that ArgoCD watches.
-
-
-
+| Information | Location |
+|-------------|----------|
+| Cluster configuration | `infra/terraform/environments/<env>/` |
+| ArgoCD applications | `gitops/clusters/<env>/apps/` |
+| Service Helm charts | `services/<name>/deployments/helm/<name>/` |
+| Shared Helm charts | `infra/helm/charts/` |
+| Self-signed certs | `infra/secrets/certs/` |

--- a/docs/platform/observability-guide.md
+++ b/docs/platform/observability-guide.md
@@ -1,8 +1,9 @@
-# Infrastructure Observability Guide
+# Observability Guide
 
-**Feature**: `001-infrastructure`  
-**Last Updated**: 2025-11-08  
-**Owner**: Platform Engineering
+---
+last_updated: 2025-12-08
+document_type: guide
+---
 
 ## Stack Components
 
@@ -137,11 +138,14 @@ Alert definitions codified in `infra/helm/charts/observability-stack/templates/a
 
 ## Onboarding Checklist
 
-- [ ] Grafana user added to `platform-observers` team.  
-- [ ] Access package includes dashboard URLs (`observability-links.json`).  
-- [ ] Alert routing documented in PagerDuty service directory.  
-- [ ] Synthetic monitors configured in Checkly (HTTP uptime per environment).  
-- [ ] Observability section in `specs/001-infrastructure/quickstart.md` reviewed.
+- [ ] Grafana user added to `platform-observers` team
+- [ ] Access package includes dashboard URLs
+- [ ] Alert routing documented in PagerDuty service directory
+- [ ] Synthetic monitors configured (HTTP uptime per environment)
 
-Update this guide whenever alert thresholds, dashboards, or tooling change.
+## Related Documentation
+
+- [Environment Access](environment-access.md) - Grafana/Loki URLs and credentials
+- [Endpoints and URLs](endpoints-and-urls.md) - All service endpoints
+- [Infrastructure Overview](infrastructure-overview.md) - Architecture context
 

--- a/docs/platform/tls-ssl-setup.md
+++ b/docs/platform/tls-ssl-setup.md
@@ -1,8 +1,9 @@
 # TLS/SSL Certificate Setup Guide
 
-**Feature**: `013-ingress-tls`  
-**Last Updated**: 2025-11-16  
-**Owner**: Platform Engineering
+---
+last_updated: 2025-12-08
+document_type: guide
+---
 
 ## Overview
 
@@ -168,8 +169,8 @@ sudo ./scripts/infra/update-hosts-file.sh
 
 ## Related Documentation
 
-- `infra/secrets/certs/README.md` - Detailed certificate management
-- `docs/platform/endpoints-and-urls.md` - Complete endpoint configuration guide
-- `tmp_md/KUBECONFIG_SETUP_SIMPLE.md` - Kubeconfig setup
-- `specs/013-ingress-tls/spec.md` - Ingress TLS specification
+- [Endpoints and URLs](endpoints-and-urls.md) - Complete endpoint configuration
+- [Environment Access](environment-access.md) - Kubeconfig and credentials
+- [Certificate Architecture](certificate-architecture.md) - Certificate design details
+- Certificate files: `infra/secrets/certs/`
 

--- a/docs/platform/ui-pages.md
+++ b/docs/platform/ui-pages.md
@@ -1,5 +1,10 @@
 # Web Portal UI Pages
 
+---
+last_updated: 2025-12-08
+document_type: reference
+---
+
 This document describes all pages in the web portal, their functionality, and the corresponding admin-cli commands where applicable.
 
 ## Page Overview
@@ -166,6 +171,7 @@ Shown when a user attempts to access a page without required permissions:
 
 ## Related Documentation
 
-- [Web Portal Spec](../../specs/008-web-portal/spec.md) - Full feature specification
-- [Admin CLI](../technical/services/admin-cli.md) - CLI installation and usage
-- [Access Control](./access-control.md) - Role-based access policies
+- [Access Control](access-control.md) - Role-based access policies
+- [Endpoints and URLs](endpoints-and-urls.md) - Web portal URL
+- Web Portal source: `web/portal/`
+- Admin CLI: `services/admin-cli/`


### PR DESCRIPTION
## Summary

- Create documentation standards (STANDARDS.md) with reference-not-duplicate principle
- Create agent navigation map (agent-infra-ops-manager.md) for efficient document discovery
- Rewrite ci-cd-pipeline.md, infrastructure-overview.md, and endpoints-and-urls.md with accurate current state
- Restructure access-control.md to separate operational vs planned features
- Fix broken references and workflow filenames across multiple files
- Remove all outdated specs/ directory references
- Add YAML frontmatter to all documentation files

## Test plan

- [ ] Review updated documentation for accuracy
- [ ] Verify navigation map covers key documents
- [ ] Confirm no broken links remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)